### PR TITLE
Add workflow runtime with in-memory engine and sample

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,44 @@
+plugins {
+    application
+}
+
+buildscript {
+    repositories {
+        mavenCentral()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/releases")
+        maven("https://plugins.gradle.org/m2/")
+    }
+    dependencies {
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
+    }
+}
+
+apply(plugin = "org.jetbrains.kotlin.jvm")
+
+group = "com.example"
+version = "1.0-SNAPSHOT"
+
+repositories {
+    mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/releases")
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+
+    testImplementation(kotlin("test"))
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+kotlin {
+    jvmToolchain(17)
+}
+
+application {
+    mainClass.set("com.example.workflow.sample.MainKt")
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+systemProp.http.agent=Mozilla/5.0
+systemProp.https.agent=Mozilla/5.0

--- a/gradlew
+++ b/gradlew
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+"$(command -v gradle)" "$@"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+SET GRADLE_EXE=gradle
+"%GRADLE_EXE%" %*

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "kotlin-workflow-runtime"

--- a/src/main/kotlin/com/example/workflow/core/Effect.kt
+++ b/src/main/kotlin/com/example/workflow/core/Effect.kt
@@ -1,0 +1,50 @@
+package com.example.workflow.core
+
+/**
+ * Represents the executable intent returned by a workflow command handler.
+ */
+sealed class Effect<S, E, R> {
+    internal data class Executable<S, E, R>(
+        val events: List<E>,
+        val transition: Transition<S>?,
+        val sideEffects: List<SideEffect<S>>,
+        val reply: ((S) -> R)?,
+        val replyType: ReplyType
+    ) : Effect<S, E, R>()
+
+    internal enum class ReplyType { WITH_REPLY, NO_REPLY }
+}
+
+/**
+ * Builder returned by DSL methods while composing workflow effects.
+ */
+interface StepEffect<S, E, R> {
+    fun thenRun(block: SideEffect<S>): StepEffect<S, E, R>
+    fun thenTransition(transition: (S) -> S): StepEffect<S, E, R>
+    fun thenReply(reply: (S) -> R): Effect<S, E, R>
+    fun thenNoReply(): Effect<S, E, R>
+}
+
+internal class StepEffectImpl<S, E, R>(
+    private val events: List<E>,
+    private val sideEffects: List<SideEffect<S>>,
+    private val transition: Transition<S>?
+) : StepEffect<S, E, R> {
+
+    override fun thenRun(block: SideEffect<S>): StepEffect<S, E, R> =
+        StepEffectImpl(events, sideEffects + block, transition)
+
+    override fun thenTransition(transition: (S) -> S): StepEffect<S, E, R> {
+        val next = Transition(transition)
+        val composed = this.transition?.let { existing ->
+            Transition<S> { state -> next.toState(existing.toState(state)) }
+        } ?: next
+        return StepEffectImpl(events, sideEffects, composed)
+    }
+
+    override fun thenReply(reply: (S) -> R): Effect<S, E, R> =
+        Effect.Executable(events, transition, sideEffects, reply, Effect.ReplyType.WITH_REPLY)
+
+    override fun thenNoReply(): Effect<S, E, R> =
+        Effect.Executable(events, transition, sideEffects, null, Effect.ReplyType.NO_REPLY)
+}

--- a/src/main/kotlin/com/example/workflow/core/Effects.kt
+++ b/src/main/kotlin/com/example/workflow/core/Effects.kt
@@ -1,0 +1,27 @@
+package com.example.workflow.core
+
+/**
+ * Entry point for building workflow effects in a fluent DSL.
+ */
+object Effects {
+    /**
+     * Creates a [StepEffect] without persisting any events.
+     */
+    fun <S, E, R> none(): StepEffect<S, E, R> = StepEffectImpl(emptyList(), emptyList(), null)
+
+    /**
+     * Creates a [StepEffect] that will persist the supplied [events] in order.
+     */
+    fun <S, E, R> persist(vararg events: E): StepEffect<S, E, R> =
+        StepEffectImpl(events.toList(), emptyList(), null)
+
+    /**
+     * Type-safe factory bound to a workflow's state, event and reply types.
+     */
+    class Factory<S, E, R> internal constructor() {
+        fun none(): StepEffect<S, E, R> = Effects.none()
+        fun persist(vararg events: E): StepEffect<S, E, R> = Effects.persist(*events)
+    }
+
+    internal fun <S, E, R> factory(): Factory<S, E, R> = Factory()
+}

--- a/src/main/kotlin/com/example/workflow/core/Transition.kt
+++ b/src/main/kotlin/com/example/workflow/core/Transition.kt
@@ -1,0 +1,6 @@
+package com.example.workflow.core
+
+/**
+ * Represents a functional transition that transforms workflow state after events are applied.
+ */
+data class Transition<S>(val toState: (S) -> S)

--- a/src/main/kotlin/com/example/workflow/core/Types.kt
+++ b/src/main/kotlin/com/example/workflow/core/Types.kt
@@ -1,0 +1,23 @@
+package com.example.workflow.core
+
+/**
+ * Represents a side-effect executed after the workflow state has been updated for a command.
+ */
+typealias SideEffect<S> = suspend (S) -> Unit
+
+/**
+ * Provides contextual information to a workflow while handling commands.
+ */
+interface WorkflowContext<S, C, E, R> {
+    /** Identifier for the workflow instance currently being processed. */
+    val id: String
+
+    /** Factory that produces [Effect] builders bound to the workflow types. */
+    val effects: Effects.Factory<S, E, R>
+}
+
+internal class DefaultWorkflowContext<S, C, E, R>(
+    override val id: String
+) : WorkflowContext<S, C, E, R> {
+    override val effects: Effects.Factory<S, E, R> = Effects.factory()
+}

--- a/src/main/kotlin/com/example/workflow/core/Workflow.kt
+++ b/src/main/kotlin/com/example/workflow/core/Workflow.kt
@@ -1,0 +1,20 @@
+package com.example.workflow.core
+
+/**
+ * Base contract for all workflows executed by the runtime.
+ */
+interface Workflow<S, C, E, R> {
+    /** Human-readable workflow name used for diagnostics. */
+    val name: String
+
+    /** Creates a brand-new state for a workflow instance. */
+    fun initialState(): S
+
+    /** Applies the given [event] to the supplied [state], producing a new state snapshot. */
+    fun applyEvent(state: S, event: E): S
+
+    /**
+     * Handles a [command] given the current [state] and must return an [Effect] describing the outcome.
+     */
+    suspend fun onCommand(state: S, command: C, ctx: WorkflowContext<S, C, E, R>): Effect<S, E, R>
+}

--- a/src/main/kotlin/com/example/workflow/runtime/InMemoryStores.kt
+++ b/src/main/kotlin/com/example/workflow/runtime/InMemoryStores.kt
@@ -1,0 +1,32 @@
+package com.example.workflow.runtime
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Thread-safe in-memory store keeping the latest workflow state per instance id.
+ */
+class InMemoryStateStore<S>(private val initialStateProvider: () -> S) {
+    private val states = ConcurrentHashMap<String, S>()
+
+    fun getState(id: String): S = states.computeIfAbsent(id) { initialStateProvider() }
+
+    fun updateState(id: String, state: S) {
+        states[id] = state
+    }
+}
+
+/**
+ * Thread-safe in-memory append-only store for workflow events.
+ */
+class InMemoryEventStore<E> {
+    private val events = ConcurrentHashMap<String, MutableList<E>>()
+
+    fun append(id: String, newEvents: List<E>) {
+        if (newEvents.isEmpty()) return
+        events.compute(id) { _, existing ->
+            (existing ?: mutableListOf<E>()).apply { addAll(newEvents) }
+        }
+    }
+
+    fun events(id: String): List<E> = events[id]?.toList() ?: emptyList()
+}

--- a/src/main/kotlin/com/example/workflow/runtime/WorkflowEngine.kt
+++ b/src/main/kotlin/com/example/workflow/runtime/WorkflowEngine.kt
@@ -1,0 +1,134 @@
+package com.example.workflow.runtime
+
+import com.example.workflow.core.DefaultWorkflowContext
+import com.example.workflow.core.Effect
+import com.example.workflow.core.Workflow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancel
+
+/**
+ * In-memory workflow engine responsible for executing workflow logic sequentially per instance id.
+ */
+class WorkflowEngine<S, C, E, R>(
+    private val workflow: Workflow<S, C, E, R>,
+    scope: CoroutineScope? = null
+) {
+    private val ownsScope = scope == null
+    private val scope: CoroutineScope = scope ?: CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val stateStore = InMemoryStateStore(workflow::initialState)
+    private val eventStore = InMemoryEventStore<E>()
+
+    internal data class CommandEnvelope<C, R>(
+        val command: C,
+        val reply: CompletableDeferred<R>?,
+        val expectReply: Boolean,
+        val completion: CompletableDeferred<Unit>
+    )
+
+    private data class WorkflowInstance<C, R>(
+        val channel: Channel<CommandEnvelope<C, R>>,
+        val job: kotlinx.coroutines.Job
+    )
+
+    private val instances = java.util.concurrent.ConcurrentHashMap<String, WorkflowInstance<C, R>>()
+
+    fun proxy(id: String): WorkflowProxy<S, C, E, R> {
+        ensureInstance(id)
+        return WorkflowProxy(id, this)
+    }
+
+    internal suspend fun submit(id: String, envelope: CommandEnvelope<C, R>) {
+        val instance = ensureInstance(id)
+        instance.channel.send(envelope)
+    }
+
+    private fun ensureInstance(id: String): WorkflowInstance<C, R> =
+        instances.computeIfAbsent(id) {
+            val channel = Channel<CommandEnvelope<C, R>>(Channel.UNLIMITED)
+            val job = scope.launch {
+                for (envelope in channel) {
+                    processEnvelope(id, envelope)
+                }
+            }
+            WorkflowInstance(channel, job)
+        }
+
+    private suspend fun processEnvelope(id: String, envelope: CommandEnvelope<C, R>) {
+        val completion = envelope.completion
+        val reply = envelope.reply
+        var failure: Throwable? = null
+        try {
+            val currentState = stateStore.getState(id)
+            val context = DefaultWorkflowContext<S, C, E, R>(id)
+            val effect = workflow.onCommand(currentState, envelope.command, context)
+            val executable = effect as? Effect.Executable<S, E, R>
+                ?: error("Unsupported effect implementation: ${'$'}effect")
+            val newState = applyEffect(id, currentState, executable)
+            when {
+                envelope.expectReply && executable.replyType == Effect.ReplyType.NO_REPLY -> {
+                    failure = IllegalStateException(
+                        "Workflow ${'$'}{workflow.name} returned no reply for command ${'$'}{envelope.command}"
+                    )
+                    reply?.completeExceptionally(failure!!)
+                }
+                envelope.expectReply -> {
+                    val replyFn = executable.reply ?: error("Reply function missing")
+                    val result = replyFn(newState)
+                    reply?.complete(result)
+                }
+                else -> {
+                    executable.reply?.invoke(newState)
+                }
+            }
+        } catch (ex: Throwable) {
+            reply?.completeExceptionally(ex)
+            completion.completeExceptionally(ex)
+            return
+        }
+        failure?.let {
+            completion.completeExceptionally(it)
+            return
+        }
+        completion.complete(Unit)
+    }
+
+    private suspend fun applyEffect(
+        id: String,
+        currentState: S,
+        effect: Effect.Executable<S, E, R>
+    ): S {
+        var newState = currentState
+        if (effect.events.isNotEmpty()) {
+            eventStore.append(id, effect.events)
+            for (event in effect.events) {
+                newState = workflow.applyEvent(newState, event)
+            }
+        }
+        effect.transition?.let { transition ->
+            newState = transition.toState(newState)
+        }
+        stateStore.updateState(id, newState)
+        for (sideEffect in effect.sideEffects) {
+            sideEffect(newState)
+        }
+        return newState
+    }
+
+    internal fun stateSnapshot(id: String): S = stateStore.getState(id)
+
+    internal fun eventLog(id: String): List<E> = eventStore.events(id)
+
+    suspend fun shutdown() {
+        instances.values.forEach { it.channel.close() }
+        instances.values.forEach { it.job.join() }
+        if (ownsScope) {
+            scope.cancel()
+        }
+        instances.clear()
+    }
+}

--- a/src/main/kotlin/com/example/workflow/runtime/WorkflowProxy.kt
+++ b/src/main/kotlin/com/example/workflow/runtime/WorkflowProxy.kt
@@ -1,0 +1,38 @@
+package com.example.workflow.runtime
+
+import kotlinx.coroutines.CompletableDeferred
+
+/**
+ * Client-facing proxy for interacting with a workflow instance.
+ */
+class WorkflowProxy<S, C, E, R> internal constructor(
+    private val id: String,
+    private val engine: WorkflowEngine<S, C, E, R>
+) {
+    /** Sends a command expecting a reply. */
+    suspend fun ask(command: C): R {
+        val reply = CompletableDeferred<R>()
+        val completion = CompletableDeferred<Unit>()
+        engine.submit(
+            id,
+            WorkflowEngine.CommandEnvelope(command, reply, expectReply = true, completion)
+        )
+        return reply.await()
+    }
+
+    /** Sends a fire-and-forget command that completes once processed. */
+    suspend fun tell(command: C) {
+        val completion = CompletableDeferred<Unit>()
+        engine.submit(
+            id,
+            WorkflowEngine.CommandEnvelope(command, reply = null, expectReply = false, completion)
+        )
+        completion.await()
+    }
+
+    /** Returns the latest state snapshot of the workflow instance. */
+    fun state(): S = engine.stateSnapshot(id)
+
+    /** Returns a copy of the persisted event log for the workflow instance. */
+    fun events(): List<E> = engine.eventLog(id)
+}

--- a/src/main/kotlin/com/example/workflow/sample/Main.kt
+++ b/src/main/kotlin/com/example/workflow/sample/Main.kt
@@ -1,0 +1,23 @@
+package com.example.workflow.sample
+
+import com.example.workflow.runtime.WorkflowEngine
+import kotlinx.coroutines.runBlocking
+
+/** Simple demo showcasing the in-memory workflow runtime. */
+fun main(): Unit = runBlocking {
+    val workflow = OrderWorkflow()
+    val engine = WorkflowEngine(workflow)
+    val proxy = engine.proxy("order-1001")
+
+    println("-- Executing order workflow demo --")
+    println(proxy.ask(OrderCommand.CreateOrder(customerId = "customer-1")))
+    println(proxy.ask(OrderCommand.AddItem("Laptop")))
+    println(proxy.ask(OrderCommand.AddItem("Mouse")))
+    println(proxy.ask(OrderCommand.Approve))
+    println(proxy.ask(OrderCommand.Ship))
+
+    println("Final state: ${'$'}{proxy.state()}")
+    println("Events: ${'$'}{proxy.events()}")
+
+    engine.shutdown()
+}

--- a/src/main/kotlin/com/example/workflow/sample/OrderWorkflow.kt
+++ b/src/main/kotlin/com/example/workflow/sample/OrderWorkflow.kt
@@ -1,0 +1,173 @@
+package com.example.workflow.sample
+
+import com.example.workflow.core.Effect
+import com.example.workflow.core.Workflow
+import com.example.workflow.core.WorkflowContext
+
+/** Represents all possible statuses for an order. */
+enum class OrderStatus { NEW, CREATED, APPROVED, SHIPPED, CANCELLED }
+
+/** Commands that can be issued to the [OrderWorkflow]. */
+sealed interface OrderCommand {
+    data class CreateOrder(val customerId: String) : OrderCommand
+    data class AddItem(val item: String) : OrderCommand
+    object Approve : OrderCommand
+    object Ship : OrderCommand
+    data class Cancel(val reason: String? = null) : OrderCommand
+}
+
+/** Events persisted by the [OrderWorkflow]. */
+sealed interface OrderEvent {
+    data class OrderCreated(val orderId: String, val customerId: String) : OrderEvent
+    data class ItemAdded(val item: String) : OrderEvent
+    object OrderApproved : OrderEvent
+    object OrderShipped : OrderEvent
+    data class OrderCancelled(val reason: String?) : OrderEvent
+}
+
+/** Replies returned to callers of the [OrderWorkflow]. */
+sealed class OrderReply(open val state: OrderState) {
+    data class Accepted(val message: String, override val state: OrderState) : OrderReply(state)
+    data class Rejected(val reason: String, override val state: OrderState) : OrderReply(state)
+}
+
+/** State maintained by the [OrderWorkflow]. */
+data class OrderState(
+    val orderId: String,
+    val customerId: String?,
+    val items: List<String>,
+    val status: OrderStatus,
+    val cancelReason: String?,
+    val version: Int
+)
+
+/** Workflow implementing a simple order life-cycle. */
+class OrderWorkflow : Workflow<OrderState, OrderCommand, OrderEvent, OrderReply> {
+    override val name: String = "order-workflow"
+
+    override fun initialState(): OrderState =
+        OrderState(orderId = "", customerId = null, items = emptyList(), status = OrderStatus.NEW, cancelReason = null, version = 0)
+
+    override fun applyEvent(state: OrderState, event: OrderEvent): OrderState = when (event) {
+        is OrderEvent.OrderCreated -> state.copy(
+            orderId = event.orderId,
+            customerId = event.customerId,
+            status = OrderStatus.CREATED,
+            cancelReason = null
+        )
+        is OrderEvent.ItemAdded -> state.copy(items = state.items + event.item)
+        OrderEvent.OrderApproved -> state.copy(status = OrderStatus.APPROVED)
+        OrderEvent.OrderShipped -> state.copy(status = OrderStatus.SHIPPED)
+        is OrderEvent.OrderCancelled -> state.copy(status = OrderStatus.CANCELLED, cancelReason = event.reason)
+    }
+
+    override suspend fun onCommand(
+        state: OrderState,
+        command: OrderCommand,
+        ctx: WorkflowContext<OrderState, OrderCommand, OrderEvent, OrderReply>
+    ): Effect<OrderState, OrderEvent, OrderReply> = when (command) {
+        is OrderCommand.CreateOrder -> handleCreate(state, command, ctx)
+        is OrderCommand.AddItem -> handleAddItem(state, command, ctx)
+        OrderCommand.Approve -> handleApprove(state, ctx)
+        OrderCommand.Ship -> handleShip(state, ctx)
+        is OrderCommand.Cancel -> handleCancel(state, command, ctx)
+    }
+
+    private fun handleCreate(
+        state: OrderState,
+        command: OrderCommand.CreateOrder,
+        ctx: WorkflowContext<OrderState, OrderCommand, OrderEvent, OrderReply>
+    ): Effect<OrderState, OrderEvent, OrderReply> {
+        if (state.status != OrderStatus.NEW) {
+            return rejection(ctx, state, "Order already created")
+        }
+        return ctx.effects.persist<OrderState, OrderEvent, OrderReply>(
+            OrderEvent.OrderCreated(orderId = ctx.id, customerId = command.customerId)
+        ).thenTransition { updated ->
+            updated.copy(version = updated.version + 1)
+        }.thenRun { updated ->
+            println("Order ${'$'}{updated.orderId} created for customer ${'$'}{updated.customerId}")
+        }.thenReply { updated ->
+            OrderReply.Accepted("Order created", updated)
+        }
+    }
+
+    private fun handleAddItem(
+        state: OrderState,
+        command: OrderCommand.AddItem,
+        ctx: WorkflowContext<OrderState, OrderCommand, OrderEvent, OrderReply>
+    ): Effect<OrderState, OrderEvent, OrderReply> {
+        if (state.status !in setOf(OrderStatus.CREATED, OrderStatus.APPROVED)) {
+            return rejection(ctx, state, "Cannot add items when order is ${'$'}{state.status}")
+        }
+        return ctx.effects.persist<OrderState, OrderEvent, OrderReply>(
+            OrderEvent.ItemAdded(command.item)
+        ).thenTransition { updated ->
+            updated.copy(version = updated.version + 1)
+        }.thenReply { updated ->
+            OrderReply.Accepted("Item added", updated)
+        }
+    }
+
+    private fun handleApprove(
+        state: OrderState,
+        ctx: WorkflowContext<OrderState, OrderCommand, OrderEvent, OrderReply>
+    ): Effect<OrderState, OrderEvent, OrderReply> {
+        if (state.status != OrderStatus.CREATED) {
+            return rejection(ctx, state, "Order must be created before approval")
+        }
+        return ctx.effects.persist<OrderState, OrderEvent, OrderReply>(
+            OrderEvent.OrderApproved
+        ).thenTransition { updated ->
+            updated.copy(status = OrderStatus.APPROVED, version = updated.version + 1)
+        }.thenRun { updated ->
+            println("Order ${'$'}{updated.orderId} approved")
+        }.thenReply { updated ->
+            OrderReply.Accepted("Order approved", updated)
+        }
+    }
+
+    private fun handleShip(
+        state: OrderState,
+        ctx: WorkflowContext<OrderState, OrderCommand, OrderEvent, OrderReply>
+    ): Effect<OrderState, OrderEvent, OrderReply> {
+        if (state.status != OrderStatus.APPROVED) {
+            return rejection(ctx, state, "Order must be approved before shipping")
+        }
+        return ctx.effects.persist<OrderState, OrderEvent, OrderReply>(
+            OrderEvent.OrderShipped
+        ).thenTransition { updated ->
+            updated.copy(status = OrderStatus.SHIPPED, version = updated.version + 1)
+        }.thenRun { updated ->
+            println("Shipping order ${'$'}{updated.orderId} containing ${'$'}{updated.items.size} items")
+        }.thenReply { updated ->
+            OrderReply.Accepted("Order shipped", updated)
+        }
+    }
+
+    private fun handleCancel(
+        state: OrderState,
+        command: OrderCommand.Cancel,
+        ctx: WorkflowContext<OrderState, OrderCommand, OrderEvent, OrderReply>
+    ): Effect<OrderState, OrderEvent, OrderReply> {
+        if (state.status !in setOf(OrderStatus.CREATED, OrderStatus.APPROVED)) {
+            return rejection(ctx, state, "Cannot cancel order when status is ${'$'}{state.status}")
+        }
+        return ctx.effects.persist<OrderState, OrderEvent, OrderReply>(
+            OrderEvent.OrderCancelled(command.reason)
+        ).thenTransition { updated ->
+            updated.copy(status = OrderStatus.CANCELLED, version = updated.version + 1)
+        }.thenReply { updated ->
+            OrderReply.Accepted("Order cancelled", updated)
+        }
+    }
+
+    private fun rejection(
+        ctx: WorkflowContext<OrderState, OrderCommand, OrderEvent, OrderReply>,
+        state: OrderState,
+        reason: String
+    ): Effect<OrderState, OrderEvent, OrderReply> =
+        ctx.effects.none<OrderState, OrderEvent, OrderReply>().thenReply {
+            OrderReply.Rejected(reason, it)
+        }
+}

--- a/src/test/kotlin/com/example/workflow/EffectDslTest.kt
+++ b/src/test/kotlin/com/example/workflow/EffectDslTest.kt
@@ -1,0 +1,51 @@
+package com.example.workflow
+
+import com.example.workflow.core.Effect
+import com.example.workflow.core.Effects
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class EffectDslTest {
+    @Test
+    fun `persist with transition and side effects`() {
+        val effect = Effects.persist<Int, String, String>("a", "b")
+            .thenTransition { state -> state + 1 }
+            .thenRun { }
+            .thenReply { state -> "state=${'$'}state" }
+
+        val exec = effect as Effect.Executable<Int, String, String>
+        assertEquals(listOf("a", "b"), exec.events)
+        assertNotNull(exec.transition)
+        assertEquals("state=3", exec.reply?.invoke(3))
+        assertEquals(Effect.ReplyType.WITH_REPLY, exec.replyType)
+        assertEquals(1, exec.sideEffects.size)
+    }
+
+    @Test
+    fun `transition composition preserves order`() {
+        val effect = Effects.none<Int, String, String>()
+            .thenTransition { it + 1 }
+            .thenTransition { it * 2 }
+            .thenReply { it.toString() }
+
+        val exec = effect as Effect.Executable<Int, String, String>
+        val transition = exec.transition
+        assertNotNull(transition)
+        assertEquals(8, transition.toState(3))
+    }
+
+    @Test
+    fun `no reply effect`() {
+        val effect = Effects.none<String, Int, String>()
+            .thenRun { }
+            .thenNoReply()
+
+        val exec = effect as Effect.Executable<String, Int, String>
+        assertTrue(exec.events.isEmpty())
+        assertEquals(Effect.ReplyType.NO_REPLY, exec.replyType)
+        assertNull(exec.reply)
+    }
+}

--- a/src/test/kotlin/com/example/workflow/EngineConcurrencyTest.kt
+++ b/src/test/kotlin/com/example/workflow/EngineConcurrencyTest.kt
@@ -1,0 +1,41 @@
+package com.example.workflow
+
+import com.example.workflow.runtime.WorkflowEngine
+import com.example.workflow.sample.OrderCommand
+import com.example.workflow.sample.OrderReply
+import com.example.workflow.sample.OrderWorkflow
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+
+class EngineConcurrencyTest {
+    private val workflow = OrderWorkflow()
+
+    @Test
+    fun `commands are serialized per instance`() = runTest {
+        val engine = WorkflowEngine(workflow, backgroundScope)
+        val proxy = engine.proxy("order-concurrency")
+        val create = proxy.ask(OrderCommand.CreateOrder("customer"))
+        assertTrue(create is OrderReply.Accepted)
+
+        coroutineScope {
+            repeat(20) { index ->
+                launch {
+                    val reply = proxy.ask(OrderCommand.AddItem("item-${'$'}index"))
+                    assertTrue(reply is OrderReply.Accepted)
+                }
+            }
+        }
+
+        val state = proxy.state()
+        assertEquals(21, state.version)
+        assertEquals(20, state.items.size)
+        assertTrue((0 until 20).all { "item-${'$'}it" in state.items })
+        assertEquals(21, proxy.events().size)
+
+        engine.shutdown()
+    }
+}

--- a/src/test/kotlin/com/example/workflow/OrderWorkflowTest.kt
+++ b/src/test/kotlin/com/example/workflow/OrderWorkflowTest.kt
@@ -1,0 +1,84 @@
+package com.example.workflow
+
+import com.example.workflow.runtime.WorkflowEngine
+import com.example.workflow.sample.OrderCommand
+import com.example.workflow.sample.OrderEvent
+import com.example.workflow.sample.OrderReply
+import com.example.workflow.sample.OrderState
+import com.example.workflow.sample.OrderStatus
+import com.example.workflow.sample.OrderWorkflow
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+class OrderWorkflowTest {
+    private val workflow = OrderWorkflow()
+    private lateinit var engine: WorkflowEngine<OrderState, OrderCommand, OrderEvent, OrderReply>
+
+    @AfterTest
+    fun tearDown() = runTest {
+        if (::engine.isInitialized) {
+            engine.shutdown()
+        }
+    }
+
+    @Test
+    fun `happy path transitions`() = runTest {
+        engine = WorkflowEngine(workflow, backgroundScope)
+        val proxy = engine.proxy("order-1")
+
+        val create = proxy.ask(OrderCommand.CreateOrder("customer-1"))
+        assertTrue(create is OrderReply.Accepted)
+
+        val add1 = proxy.ask(OrderCommand.AddItem("laptop"))
+        val add2 = proxy.ask(OrderCommand.AddItem("mouse"))
+        assertTrue(add1 is OrderReply.Accepted && add2 is OrderReply.Accepted)
+
+        val approve = proxy.ask(OrderCommand.Approve)
+        val ship = proxy.ask(OrderCommand.Ship)
+        assertTrue(approve is OrderReply.Accepted && ship is OrderReply.Accepted)
+
+        val state = proxy.state()
+        assertEquals(OrderStatus.SHIPPED, state.status)
+        assertEquals(2, state.items.size)
+        assertEquals(5, state.version)
+
+        val events = proxy.events()
+        assertEquals(5, events.size)
+        assertTrue(events[0] is OrderEvent.OrderCreated)
+        assertTrue(events[1] is OrderEvent.ItemAdded)
+        assertTrue(events[2] is OrderEvent.ItemAdded)
+        assertTrue(events[3] is OrderEvent.OrderApproved)
+        assertTrue(events[4] is OrderEvent.OrderShipped)
+    }
+
+    @Test
+    fun `invalid transition produces rejection`() = runTest {
+        engine = WorkflowEngine(workflow, backgroundScope)
+        val proxy = engine.proxy("order-2")
+        proxy.ask(OrderCommand.CreateOrder("customer-1"))
+
+        val reply = proxy.ask(OrderCommand.Ship)
+        assertTrue(reply is OrderReply.Rejected)
+        assertEquals(OrderStatus.CREATED, proxy.state().status)
+        assertEquals(1, proxy.events().size)
+    }
+
+    @Test
+    fun `cancelled order rejects further commands`() = runTest {
+        engine = WorkflowEngine(workflow, backgroundScope)
+        val proxy = engine.proxy("order-3")
+        proxy.ask(OrderCommand.CreateOrder("customer-2"))
+        proxy.ask(OrderCommand.AddItem("keyboard"))
+
+        val cancel = proxy.ask(OrderCommand.Cancel("customer request"))
+        assertTrue(cancel is OrderReply.Accepted)
+        assertEquals(OrderStatus.CANCELLED, proxy.state().status)
+
+        val after = proxy.ask(OrderCommand.AddItem("mouse"))
+        assertTrue(after is OrderReply.Rejected)
+        assertEquals(3, proxy.events().size)
+    }
+}


### PR DESCRIPTION
## Summary
- implement core Effect/StepEffect/Transition abstractions with a fluent DSL and workflow context helpers
- add in-memory state/event stores plus a coroutine-powered workflow engine and proxy
- provide an order workflow domain sample, demo main entry point, and unit tests covering DSL and runtime behaviour

## Testing
- ./gradlew clean build --console=plain --no-daemon *(fails: Maven repositories return HTTP 403 during dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ea6c9c8c832494798697ae2e8c99