### PR TITLE
Implement Kotlin Workflow Runtime v2.1 scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
-# KotlinWorkflowRuntime-EffectStepEffectTransition-WithIn-MemoryProxy
-Implement a minimal yet robust workflow runtime in Kotlin that models Akka-style Effect/StepEffect/Transition semantics and provides an in-memory proxy/engine to execute workflows. The runtime must be generic and type-safe, support event-sourced state evolution via events, allow state transitions via a Transition step
+# Kotlin Workflow Runtime — Effect/StepEffect/Transition Engine
+
+This repository hosts a Kotlin workflow runtime that models Akka-style Effect/StepEffect/Transition semantics and includes an in-memory proxy/engine for executing workflows with event-sourced state evolution.
+
+## Specifications
+
+- [v2.1 Supplement — Reliability, DSL+, Performance, Ops, Security, DX](docs/spec/v2.1-supplement.md)
+
+The v2.1 supplement layers on top of the existing v2 design to introduce exactly-once guarantees, multi-region failover, PITR/archival, schema upcasting, crypto audit chains, CQRS projections, human-in-the-loop workflows, sub-workflows, enhanced timers, guard DSLs, performance optimizations, operations tooling, security controls, and developer experience improvements.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ buildscript {
 
 allprojects {
     group = "com.example"
-    version = "2.0-SNAPSHOT"
+    version = "2.1-SNAPSHOT"
 
     repositories {
         mavenCentral()

--- a/docs/spec/v2.1-supplement.md
+++ b/docs/spec/v2.1-supplement.md
@@ -1,0 +1,459 @@
+# Kotlin Workflow Runtime v2.1 — Reliability, DSL+, Performance, Ops, Security, DX
+
+This document supplements the v2 specification with additional requirements for reliability, DSL expressiveness, performance, operations, security, and developer experience. It is organized into concise requirement summaries followed by interfaces, DDL/configuration fragments, and acceptance criteria.
+
+## 0. Module Changes
+
+### New or Extended Modules
+- **workflow-projections** — CQRS projections
+- **workflow-human** — human-in-the-loop support
+- **workflow-subflow** — sub-workflows
+- **workflow-security** — RBAC/OPA, PII controls
+- **workflow-admin** — HTTP/gRPC admin API with optional UI
+- **workflow-devtools** — Gradle plugin and scenario runner
+
+### Existing Module Extensions
+- `workflow-persistence-jdbc`
+- `workflow-transport-kafka`
+- `workflow-timers`
+- `workflow-saga`
+
+## 1. Data Reliability & Audit
+
+### 1.1 Exactly-once to the Outside World (Outbox + Kafka EOS)
+
+**Interfaces**
+```kotlin
+interface OutboxDispatcher {
+  suspend fun publishBatch(max: Int): Int
+}
+
+data class OutboxRecord(
+  val id: UUID,
+  val channel: String,
+  val key: String,
+  val headers: Map<String,String> = emptyMap(),
+  val payloadJson: String,
+  val createdAt: Instant,
+  val publishedAt: Instant? = null,
+  val attempts: Int = 0,
+  val lastError: String? = null
+)
+```
+
+**DDL (Postgres)**
+```sql
+CREATE TABLE outbox(
+  id UUID PRIMARY KEY,
+  channel TEXT NOT NULL,
+  msg_key TEXT NOT NULL,
+  headers JSONB NOT NULL DEFAULT '{}',
+  payload_json JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  published_at TIMESTAMPTZ NULL,
+  attempts INT NOT NULL DEFAULT 0,
+  last_error TEXT NULL
+);
+CREATE INDEX ON outbox (published_at) WHERE published_at IS NULL;
+```
+
+**Configuration**
+```
+outbox.eos.enabled=true
+outbox.dispatch.interval=200ms
+outbox.batch.size=200
+```
+
+**Acceptance**
+- Re-publishing the same `OutboxRecord` does not create duplicates in the target topic when EOS is enabled.
+- Injecting a failure between `send` and `commitTransaction` and restarting results in exactly one publish of the row.
+
+### 1.2 Multi-region / Disaster Recovery
+
+**Configuration**
+```
+region.role=PRIMARY|SECONDARY
+dr.replication=db-async, kafka-mirror
+dr.failover.rpo.seconds<=5
+```
+
+**Acceptance**
+- Integration scenario: primary Postgres/Kafka go down, secondary is promoted, and the service resumes with RPO ≤ 5 seconds while preserving per-`workflowId` ordering.
+
+### 1.3 Point-in-time Recovery / Archival / Replay
+
+**Interfaces**
+```kotlin
+interface Archiver { suspend fun archive(before: Instant): Int }
+interface Replayer { suspend fun replay(range: SequenceRange): ReplayReport }
+```
+
+**DDL**
+```sql
+CREATE TABLE archive_manifest(
+  id BIGSERIAL PRIMARY KEY,
+  range_from BIGINT NOT NULL,
+  range_to BIGINT NOT NULL,
+  location TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL
+);
+```
+
+**Acceptance**
+- Archiving events older than *N* days moves them to external storage.
+- Replay rebuilds the projection bit-for-bit identical to the baseline.
+
+### 1.4 Schema Registry & Upcasting
+
+**Interfaces**
+```kotlin
+interface SchemaRegistry { fun current(type: String): Int; fun get(type: String, version: Int): String }
+interface EventUpcaster { fun canUpcast(type: String, from: Int): Boolean; fun upcast(json: String, from: Int, to: Int): String }
+```
+
+**DDL**
+```sql
+CREATE TABLE schema_versions(
+  type TEXT,
+  version INT,
+  schema_json JSONB,
+  PRIMARY KEY(type, version)
+);
+```
+
+**Acceptance**
+- Events with older versions are read and upcast to the current schema without failures.
+- Mixed journals containing versions such as v1 and v3 fully apply.
+
+### 1.5 Crypto Audit (Hash Chain)
+
+**DDL (event journal change)**
+```sql
+ALTER TABLE event_journal
+  ADD COLUMN prev_hash BYTEA,
+  ADD COLUMN hash BYTEA,
+  ADD COLUMN hash_algo TEXT DEFAULT 'SHA-256';
+```
+
+**Acceptance**
+- Mutating any journal row breaks chain verification, the validator reports failure, and the event is routed to the DLQ.
+
+## 2. Workflow DSL & Capabilities
+
+### 2.1 Projections (CQRS)
+
+**Interfaces**
+```kotlin
+interface Projection {
+  val name: String
+  suspend fun start(from: Offset?)
+  suspend fun stop()
+}
+
+interface ProjectionHandler {
+  suspend fun on(event: JournalEvent, tx: ProjectionTx)
+}
+interface ProjectionTx { suspend fun upsert(sql: String, params: List<Any?>) }
+```
+
+**DDL**
+```sql
+CREATE TABLE projection_offsets(
+  name TEXT PRIMARY KEY,
+  journal_seq BIGINT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL
+);
+```
+
+**Acceptance**
+- Backfill followed by live processing catches up after startup and maintains ≤ 1 second lag.
+- Idempotency is proven by re-running the stream.
+
+### 2.2 Human-in-the-loop
+
+**Effects**
+```kotlin
+object Effects {
+  fun <S,E,R> awaitHuman(
+    token: String,
+    ttl: Duration,
+    payload: String,
+    notifyChannel: String? = null
+  ): StepEffect<S,E,R>
+}
+```
+
+**Gateway API**
+```
+POST /approvals/{token}/resume
+Body: {"decision":"APPROVE"|"REJECT", "payload": {...}}
+```
+
+**DDL**
+```sql
+CREATE TABLE pending_human_tasks(
+  token TEXT PRIMARY KEY,
+  workflow_type TEXT NOT NULL,
+  workflow_id TEXT NOT NULL,
+  payload JSONB NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('PENDING','RESUMED','EXPIRED','CANCELLED')),
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL
+);
+```
+
+**Acceptance**
+- Resuming by token unblocks the workflow.
+- Double resumption is rejected.
+- Expired tokens cannot be resumed.
+
+### 2.3 Sub-workflows
+
+**Effects**
+```kotlin
+data class ChildOptions(val awaitCompletion: Boolean = false, val correlationKey: String? = null)
+object Effects {
+  fun <S,E,R> startChild(
+    childType: String,
+    childId: String,
+    initialCommandJson: String,
+    options: ChildOptions = ChildOptions()
+  ): StepEffect<S,E,R>
+}
+```
+
+**DDL**
+```sql
+CREATE TABLE child_workflows(
+  parent_type TEXT,
+  parent_id TEXT,
+  child_type TEXT,
+  child_id TEXT,
+  status TEXT NOT NULL,
+  result_json JSONB NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY(parent_type, parent_id, child_type, child_id)
+);
+```
+
+**Acceptance**
+- Child workflows start exactly once (idempotent) and statuses are tracked.
+- With `awaitCompletion=true`, the parent continues only after the child result is recorded.
+
+### 2.4 Rich Timers
+
+**Effects**
+```kotlin
+object Effects {
+  fun <S,E,R> scheduleCron(key: String, cron: String, jitter: Duration? = null): StepEffect<S,E,R>
+  fun <S,E,R> massReschedule(selector: TimerSelector, shift: Duration): StepEffect<S,E,R>
+}
+
+data class TimerSelector(val prefix: String? = null, val tags: Set<String> = emptySet())
+```
+
+**DDL**
+```sql
+ALTER TABLE timers
+  ADD COLUMN cron_expr TEXT NULL,
+  ADD COLUMN jitter_ms INT NULL,
+  ADD COLUMN tags TEXT[] DEFAULT '{}';
+```
+
+**Acceptance**
+- Cron scheduling produces a series of `fire_at` rows.
+- `cancelTimer` stops future firings.
+- Jitter spreads load over time.
+
+### 2.5 Invariants / Guard DSL
+
+**API**
+```kotlin
+interface GuardCheck<S,C,E,R> {
+  fun orReject(buildReply: (S) -> R): Effect<S,E,R>
+  fun orThrow(message: String = "Guard violated"): Nothing
+}
+
+fun <S,C,E,R> WorkflowContext<S,C,E,R>.guard(
+  name: String,
+  state: S,
+  cmd: C,
+  predicate: (S, C) -> Boolean
+): GuardCheck<S,C,E,R>
+```
+
+**Acceptance**
+- Invariant violations return the prescribed rejection without changing state.
+- Metric `guard_violations{name}` increments.
+
+## 3. Performance & Scale
+
+### 3.1 Adaptive Snapshots
+
+**Configuration**
+```
+snapshot.maxEvents=500
+snapshot.maxStateBytes=262144
+snapshot.minInterval=5s
+```
+
+**Acceptance**
+- As state size or event rate grows, snapshots occur more frequently.
+- Recovery time improves by at least a configurable percentage versus baseline (fixed in CI).
+
+### 3.2 Priorities & Backpressure
+
+**Command Envelope Extension**
+```kotlin
+enum class Priority { HIGH, NORMAL, LOW }
+data class CommandEnvelope(..., val priority: Priority = Priority.NORMAL, val tenantId: String? = null)
+```
+
+**Configuration**
+```
+backpressure.maxActivePerPartition=2000
+priority.weights=HIGH:5,NORMAL:1,LOW:1
+rate.limit.perTenant.default=500 rps
+```
+
+**Acceptance**
+- Under mixed traffic, `HIGH` priority commands are served at least 5× as often as others.
+- Per-tenant limits are enforced.
+
+### 3.3 Warm Cache & Batch Append
+
+**Acceptance**
+- Hot instances remain cached.
+- Batch append reduces p95 DB transaction duration by at least 20% in synthetic tests.
+
+## 4. Observability & Operations
+
+### 4.1 Admin API
+
+**HTTP Endpoints**
+- `GET /workflows/{type}/{id}` → state and last sequence
+- `GET /workflows/{type}/{id}/events?from=seq`
+- `POST /workflows/{type}/{id}/replay`
+- `POST /poison/{topic}/{offset}` → move to DLQ
+- `GET /timers?dueBefore=...`
+- `POST /timers/reschedule`
+- `GET /projections/{name}/offset`
+
+**Acceptance**
+- All endpoints are authenticated and authorized via RBAC.
+- Operations are idempotent.
+- DLQ entries are inspectable through the API.
+
+### 4.2 Chaos Tests & Causal Tracing
+
+**Interfaces**
+```kotlin
+interface FaultInjector { fun inject(point: String) }
+```
+
+**Acceptance**
+- Injected faults do not break invariants: journal, snapshots, timers, and outbox remain consistent.
+- Traces link command → DB → outbox → reply.
+
+## 5. Security & Multi-tenancy
+
+### 5.1 RBAC / OPA
+
+**Interface**
+```kotlin
+interface PolicyEngine {
+  fun authorize(subject: Subject, action: Action, resource: Resource): Decision
+}
+```
+
+**Acceptance**
+- Forbidden commands are rejected at the gateway before being enqueued to Kafka.
+- Audit logs record rejection reasons.
+
+### 5.2 PII Hygiene & Right to be Forgotten
+
+**Annotation & Redactor**
+```kotlin
+@Target(AnnotationTarget.PROPERTY)
+annotation class Sensitive(val field: String)
+
+interface Redactor { fun redact(json: String): String }
+```
+
+**Crypto Envelope**
+- Field-level encryption uses `cipher:{keyId, iv, ct}` with keys managed via a KeyVault SPI.
+
+**Acceptance**
+- Exporting state without keys keeps PII unreadable.
+- A “forget user” operation makes data irrecoverable by re-encrypting or dropping keys and overlaying a redacted snapshot.
+
+### 5.3 Multi-tenancy
+
+**DDL (main tables)**
+```sql
+ALTER TABLE event_journal ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'public';
+-- Apply the same column to snapshots, outbox, timers, sagas, projection_offsets, child_workflows
+CREATE INDEX ON event_journal(tenant_id, workflow_type, workflow_id);
+```
+
+**Acceptance**
+- Queries and metrics are scoped by `tenant_id`.
+- Quotas and limits apply when publishing commands.
+
+## 6. Developer Experience
+
+### 6.1 Gradle Plugin
+
+**Tasks**
+- `workflowInit --name Order` (scaffold)
+- `workflowGen --type order --events ... --commands ...`
+- `workflowScenario --file sample.yaml`
+
+**Acceptance**
+- Generated code compiles without manual edits.
+- Scenario runner reproduces end-to-end behavior identical to manual runs.
+
+### 6.2 Property-based & Diagram-style Tests
+
+- Provide support for jqwik or `kotlin-test` property testing as an optional dependency.
+
+**Acceptance**
+- Invariants and guard rules validate against random command sequences (≥ 10k).
+
+## 7. Configuration Fragment
+
+```
+outbox { eos { enabled=true }, dispatch { interval="200ms", batchSize=200 } }
+snapshot { maxEvents=500, maxStateBytes="256KB", minInterval="5s" }
+backpressure { maxActivePerPartition=2000 }
+priority { weights = { HIGH=5, NORMAL=1, LOW=1 } }
+rateLimit { perTenantDefault=500 }
+timers { scanInterval="250ms", jitterMax="500ms" }
+security { rbac=OPA, policyFile="/etc/policy.rego" }
+tenancy { defaultTenant="public", enforce=true }
+```
+
+## 8. Acceptance Criteria Summary
+
+- **Exactly-once outbound**: duplicate publishes collapse into a single topic fact; failure between `send` and commit → exactly one publish after restart.
+- **DR**: failover ≤ RPO 5 seconds, preserving per-`workflowId` order.
+- **PITR/Replay**: reconstructed projection equals baseline bit-for-bit.
+- **Schemas/Upcasting**: mixed event versions apply without errors.
+- **Crypto audit**: hash chain verification detects manual journal edits.
+- **Projections**: lag ≤ 1 second under live traffic; idempotent re-run.
+- **Human loop**: token resumes exactly once; expired tokens rejected.
+- **Sub-workflows**: `startChild` idempotent; `awaitCompletion` survives restarts.
+- **Timers**: cron sequences, cancellations, mass reschedule; jitter spreads load.
+- **Guard DSL**: violation → rejection without state change; metric increments.
+- **Adaptive snapshots**: recovery faster than baseline by ≥ configured percentage.
+- **Priorities/Limits**: `HIGH` served ≥ 5×; per-tenant quotas enforced.
+- **Admin API**: operations authorized; DLQ manageable via API.
+- **Chaos tests**: fault points preserve consistency; commands applied idempotently.
+- **PII/Forgetting**: keys keep PII unreadable; forget makes data irrecoverable.
+- **DX**: generators produce working code; scenario runner matches manual runs.
+
+## 9. Compatibility & Migration
+
+- DSL v2 remains valid; v2.1 features are optional extensions.
+- Database migration via Flyway (idempotent `ALTER`/`CREATE`).
+- v2 nodes can co-exist with v2.1 nodes with features disabled via configuration.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,5 +17,11 @@ include(
     "workflow-saga",
     "workflow-gateway",
     "workflow-sample",
-    "workflow-integration-tests"
+    "workflow-integration-tests",
+    "workflow-projections",
+    "workflow-human",
+    "workflow-subflow",
+    "workflow-security",
+    "workflow-admin",
+    "workflow-devtools"
 )

--- a/workflow-admin/build.gradle.kts
+++ b/workflow-admin/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    `java-library`
+}
+
+apply(plugin = "org.jetbrains.kotlin.jvm")
+
+dependencies {
+    api(project(":workflow-core"))
+    api(kotlin("stdlib"))
+    testImplementation(kotlin("test"))
+}
+
+java {
+    withSourcesJar()
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/workflow-admin/src/main/kotlin/com/example/workflow/admin/AdminApi.kt
+++ b/workflow-admin/src/main/kotlin/com/example/workflow/admin/AdminApi.kt
@@ -1,0 +1,42 @@
+package com.example.workflow.admin
+
+import com.example.workflow.core.StepEffect
+
+data class WorkflowStateResponse(
+    val workflowType: String,
+    val workflowId: String,
+    val stateJson: String,
+    val lastSequence: Long
+)
+
+data class EventsResponse(val eventsJson: List<String>)
+
+data class TimerDescriptor(
+    val key: String,
+    val dueAtEpochMilli: Long,
+    val cronExpr: String?,
+    val jitterMs: Int?,
+    val tags: Set<String>
+)
+
+data class ProjectionOffset(val name: String, val journalSeq: Long)
+
+data class DlqMoveRequest(val topic: String, val offset: Long)
+
+data class ReplayRequest(val fromSeq: Long?, val toSeq: Long?)
+
+interface AdminService {
+    suspend fun getWorkflow(type: String, id: String): WorkflowStateResponse?
+    suspend fun listEvents(type: String, id: String, fromSequence: Long?): EventsResponse
+    suspend fun replayWorkflow(type: String, id: String, request: ReplayRequest): StepEffect<*, *, *>?
+    suspend fun moveToDlq(topic: String, offset: Long): StepEffect<*, *, *>?
+    suspend fun listTimers(dueBeforeEpochMilli: Long): List<TimerDescriptor>
+    suspend fun rescheduleTimers(selector: TimerSelectorRequest): Int
+    suspend fun getProjectionOffset(name: String): ProjectionOffset?
+}
+
+data class TimerSelectorRequest(
+    val prefix: String? = null,
+    val tags: Set<String> = emptySet(),
+    val shiftMillis: Long = 0
+)

--- a/workflow-admin/src/test/kotlin/com/example/workflow/admin/AdminServiceTest.kt
+++ b/workflow-admin/src/test/kotlin/com/example/workflow/admin/AdminServiceTest.kt
@@ -1,0 +1,25 @@
+package com.example.workflow.admin
+
+import com.example.workflow.core.StepEffect
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+private class InMemoryAdminService : AdminService {
+    override suspend fun getWorkflow(type: String, id: String): WorkflowStateResponse? = null
+    override suspend fun listEvents(type: String, id: String, fromSequence: Long?): EventsResponse = EventsResponse(emptyList())
+    override suspend fun replayWorkflow(type: String, id: String, request: ReplayRequest): StepEffect<*, *, *>? = null
+    override suspend fun moveToDlq(topic: String, offset: Long): StepEffect<*, *, *>? = null
+    override suspend fun listTimers(dueBeforeEpochMilli: Long): List<TimerDescriptor> = emptyList()
+    override suspend fun rescheduleTimers(selector: TimerSelectorRequest): Int = 0
+    override suspend fun getProjectionOffset(name: String): ProjectionOffset? = null
+}
+
+class AdminServiceTest {
+    @Test
+    fun `in memory service returns null`() {
+        val service = InMemoryAdminService()
+        assertNull(service.getWorkflow("Order", "1"))
+        assertEquals(0, service.rescheduleTimers(TimerSelectorRequest()))
+    }
+}

--- a/workflow-core/src/main/kotlin/com/example/workflow/core/CommandEnvelope.kt
+++ b/workflow-core/src/main/kotlin/com/example/workflow/core/CommandEnvelope.kt
@@ -1,0 +1,12 @@
+package com.example.workflow.core
+
+enum class Priority { HIGH, NORMAL, LOW }
+
+data class CommandEnvelope<C>(
+    val workflowType: String,
+    val workflowId: String,
+    val command: C,
+    val priority: Priority = Priority.NORMAL,
+    val tenantId: String? = null,
+    val metadata: Map<String, String> = emptyMap()
+)

--- a/workflow-core/src/main/kotlin/com/example/workflow/core/StepEffect.kt
+++ b/workflow-core/src/main/kotlin/com/example/workflow/core/StepEffect.kt
@@ -1,0 +1,79 @@
+package com.example.workflow.core
+
+/**
+ * Represents a logical side effect emitted by a workflow step.
+ *
+ * The runtime interprets the [name] and [attributes] to trigger the correct
+ * transport, timer or persistence integration.
+ */
+data class StepEffect<S, E, R>(
+    val name: String,
+    val attributes: Map<String, Any?> = emptyMap()
+)
+
+/**
+ * Lightweight description of a reply or command effect produced by the DSL.
+ */
+data class Effect<S, E, R>(
+    val type: String,
+    val payload: R? = null,
+    val reason: String? = null
+)
+
+/**
+ * Context available to workflow handlers during execution.
+ */
+interface WorkflowContext<S, C, E, R> {
+    val state: S
+
+    /**
+     * Records that a guard named [name] has been violated. Implementations can
+     * increment counters or emit structured telemetry.
+     */
+    fun onGuardViolation(name: String)
+
+    fun effect(type: String, payload: R? = null, reason: String? = null): Effect<S, E, R> =
+        Effect(type = type, payload = payload, reason = reason)
+}
+
+/**
+ * Exception thrown when guard checks are configured to throw.
+ */
+class GuardViolationException(message: String) : IllegalStateException(message)
+
+interface GuardCheck<S, C, E, R> {
+    fun orReject(buildReply: (S) -> R): Effect<S, E, R>
+    fun orThrow(message: String = "Guard violated"): Nothing
+}
+
+fun <S, C, E, R> WorkflowContext<S, C, E, R>.guard(
+    name: String,
+    state: S,
+    cmd: C,
+    predicate: (S, C) -> Boolean
+): GuardCheck<S, C, E, R> = GuardCheckImpl(this, name, state, cmd, predicate(state, cmd))
+
+private class GuardCheckImpl<S, C, E, R>(
+    private val context: WorkflowContext<S, C, E, R>,
+    private val name: String,
+    private val state: S,
+    private val cmd: C,
+    private val passed: Boolean
+) : GuardCheck<S, C, E, R> {
+    override fun orReject(buildReply: (S) -> R): Effect<S, E, R> {
+        return if (passed) {
+            context.effect(type = "noop")
+        } else {
+            context.onGuardViolation(name)
+            context.effect(type = "rejection", payload = buildReply(state), reason = "Guard '$name' rejected command $cmd")
+        }
+    }
+
+    override fun orThrow(message: String): Nothing {
+        if (passed) {
+            throw IllegalStateException("Guard '$name' marked as throw unexpectedly evaluated to true")
+        }
+        context.onGuardViolation(name)
+        throw GuardViolationException(message)
+    }
+}

--- a/workflow-core/src/test/kotlin/com/example/workflow/core/CommandEnvelopeTest.kt
+++ b/workflow-core/src/test/kotlin/com/example/workflow/core/CommandEnvelopeTest.kt
@@ -1,0 +1,30 @@
+package com.example.workflow.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class CommandEnvelopeTest {
+    @Test
+    fun `defaults to normal priority`() {
+        val envelope = CommandEnvelope(workflowType = "Order", workflowId = "123", command = "Create")
+        assertEquals(Priority.NORMAL, envelope.priority)
+        assertNull(envelope.tenantId)
+    }
+
+    @Test
+    fun `uses provided metadata`() {
+        val envelope = CommandEnvelope(
+            workflowType = "Order",
+            workflowId = "123",
+            command = "Create",
+            priority = Priority.HIGH,
+            tenantId = "acme",
+            metadata = mapOf("source" to "api")
+        )
+
+        assertEquals("api", envelope.metadata["source"])
+        assertEquals(Priority.HIGH, envelope.priority)
+        assertEquals("acme", envelope.tenantId)
+    }
+}

--- a/workflow-core/src/test/kotlin/com/example/workflow/core/GuardDslTest.kt
+++ b/workflow-core/src/test/kotlin/com/example/workflow/core/GuardDslTest.kt
@@ -1,0 +1,47 @@
+package com.example.workflow.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+private data class StubContext(
+    override val state: Int,
+    var violations: MutableList<String> = mutableListOf()
+) : WorkflowContext<Int, String, String, String> {
+    override fun onGuardViolation(name: String) {
+        violations.add(name)
+    }
+}
+
+class GuardDslTest {
+    @Test
+    fun `guard passes when predicate true`() {
+        val ctx = StubContext(state = 1)
+        val effect = ctx.guard("positive", ctx.state, "command") { state, _ -> state > 0 }
+            .orReject { "rejected" }
+
+        assertEquals(Effect(type = "noop"), effect)
+        assertEquals(emptyList(), ctx.violations)
+    }
+
+    @Test
+    fun `guard rejects and records violation`() {
+        val ctx = StubContext(state = -1)
+        val effect = ctx.guard("positive", ctx.state, "command") { state, _ -> state > 0 }
+            .orReject { state -> "state $state" }
+
+        assertEquals("positive", ctx.violations.single())
+        assertEquals("rejection", effect.type)
+        assertEquals("state -1", effect.payload)
+    }
+
+    @Test
+    fun `guard throws when configured`() {
+        val ctx = StubContext(state = 0)
+        assertFailsWith<GuardViolationException> {
+            ctx.guard("non-zero", ctx.state, "command") { state, _ -> state != 0 }
+                .orThrow("Must be non-zero")
+        }
+        assertEquals(listOf("non-zero"), ctx.violations)
+    }
+}

--- a/workflow-devtools/build.gradle.kts
+++ b/workflow-devtools/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    `kotlin-dsl`
+    `java-gradle-plugin`
+}
+
+dependencies {
+    implementation(gradleApi())
+    implementation(localGroovy())
+    implementation(kotlin("stdlib"))
+    testImplementation(kotlin("test"))
+}
+
+gradlePlugin {
+    plugins {
+        create("workflowDevtools") {
+            id = "com.example.workflow.devtools"
+            implementationClass = "com.example.workflow.devtools.WorkflowDevtoolsPlugin"
+        }
+    }
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/workflow-devtools/src/main/kotlin/com/example/workflow/devtools/WorkflowDevtoolsPlugin.kt
+++ b/workflow-devtools/src/main/kotlin/com/example/workflow/devtools/WorkflowDevtoolsPlugin.kt
@@ -1,0 +1,53 @@
+package com.example.workflow.devtools
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskProvider
+
+class WorkflowDevtoolsPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        val initTask = target.tasks.register("workflowInit", ScaffoldTask::class.java) {
+            description = "Scaffold a new workflow type"
+        }
+        target.tasks.register("workflowGen", GenerateCodeTask::class.java) {
+            description = "Generate workflow handlers from a schema"
+            dependsOn(initTask)
+        }
+        target.tasks.register("workflowScenario", ScenarioTask::class.java) {
+            description = "Run workflow scenario from YAML definition"
+        }
+    }
+}
+
+abstract class ScaffoldTask : org.gradle.api.DefaultTask() {
+    init {
+        group = "workflow"
+    }
+
+    @org.gradle.api.tasks.TaskAction
+    fun scaffold() {
+        project.logger.lifecycle("Scaffolding workflow named ${'$'}{project.findProperty("workflowName") ?: "Sample"}")
+    }
+}
+
+abstract class GenerateCodeTask : org.gradle.api.DefaultTask() {
+    init {
+        group = "workflow"
+    }
+
+    @org.gradle.api.tasks.TaskAction
+    fun generate() {
+        project.logger.lifecycle("Generating workflow code for type ${'$'}{project.findProperty("workflowType") ?: "Unknown"}")
+    }
+}
+
+abstract class ScenarioTask : org.gradle.api.DefaultTask() {
+    init {
+        group = "verification"
+    }
+
+    @org.gradle.api.tasks.TaskAction
+    fun runScenario() {
+        project.logger.lifecycle("Running workflow scenario ${'$'}{project.findProperty("workflowScenarioFile") ?: "scenario.yaml"}")
+    }
+}

--- a/workflow-devtools/src/main/resources/META-INF/gradle-plugins/com.example.workflow.devtools.properties
+++ b/workflow-devtools/src/main/resources/META-INF/gradle-plugins/com.example.workflow.devtools.properties
@@ -1,0 +1,1 @@
+implementation-class=com.example.workflow.devtools.WorkflowDevtoolsPlugin

--- a/workflow-devtools/src/test/kotlin/com/example/workflow/devtools/WorkflowDevtoolsPluginTest.kt
+++ b/workflow-devtools/src/test/kotlin/com/example/workflow/devtools/WorkflowDevtoolsPluginTest.kt
@@ -1,0 +1,17 @@
+package com.example.workflow.devtools
+
+import org.gradle.testfixtures.ProjectBuilder
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class WorkflowDevtoolsPluginTest {
+    @Test
+    fun `plugin registers tasks`() {
+        val project = ProjectBuilder.builder().build()
+        project.pluginManager.apply("com.example.workflow.devtools")
+
+        assertNotNull(project.tasks.findByName("workflowInit"))
+        assertNotNull(project.tasks.findByName("workflowGen"))
+        assertNotNull(project.tasks.findByName("workflowScenario"))
+    }
+}

--- a/workflow-human/build.gradle.kts
+++ b/workflow-human/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    `java-library`
+}
+
+apply(plugin = "org.jetbrains.kotlin.jvm")
+
+dependencies {
+    api(project(":workflow-core"))
+    api(kotlin("stdlib"))
+    testImplementation(kotlin("test"))
+}
+
+java {
+    withSourcesJar()
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/workflow-human/src/main/kotlin/com/example/workflow/human/HumanEffects.kt
+++ b/workflow-human/src/main/kotlin/com/example/workflow/human/HumanEffects.kt
@@ -1,0 +1,41 @@
+package com.example.workflow.human
+
+import com.example.workflow.core.StepEffect
+import kotlin.time.Duration
+
+object HumanEffects {
+    fun <S, E, R> awaitHuman(
+        token: String,
+        ttl: Duration,
+        payload: String,
+        notifyChannel: String? = null
+    ): StepEffect<S, E, R> = StepEffect(
+        name = "await-human",
+        attributes = buildMap {
+            put("token", token)
+            put("ttlMillis", ttl.inWholeMilliseconds)
+            put("payload", payload)
+            notifyChannel?.let { put("notifyChannel", it) }
+        }
+    )
+}
+
+data class PendingHumanTask(
+    val token: String,
+    val workflowType: String,
+    val workflowId: String,
+    val payload: String,
+    val status: HumanTaskStatus,
+    val expiresAtEpochMilli: Long,
+    val createdAtEpochMilli: Long
+)
+
+enum class HumanTaskStatus { PENDING, RESUMED, EXPIRED, CANCELLED }
+
+fun interface HumanTaskGateway {
+    suspend fun resume(token: String, decision: HumanDecision)
+}
+
+data class HumanDecision(val decision: Decision, val payloadJson: String) {
+    enum class Decision { APPROVE, REJECT }
+}

--- a/workflow-human/src/test/kotlin/com/example/workflow/human/HumanEffectsTest.kt
+++ b/workflow-human/src/test/kotlin/com/example/workflow/human/HumanEffectsTest.kt
@@ -1,0 +1,22 @@
+package com.example.workflow.human
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.minutes
+
+class HumanEffectsTest {
+    @Test
+    fun `await human encodes attributes`() {
+        val effect = HumanEffects.awaitHuman<Unit, Unit, Unit>(
+            token = "token-1",
+            ttl = 5.minutes,
+            payload = "{}",
+            notifyChannel = "slack"
+        )
+
+        assertEquals("await-human", effect.name)
+        assertEquals("token-1", effect.attributes["token"])
+        assertEquals(5.minutes.inWholeMilliseconds, effect.attributes["ttlMillis"])
+        assertEquals("slack", effect.attributes["notifyChannel"])
+    }
+}

--- a/workflow-persistence-jdbc/src/main/kotlin/com/example/workflow/persistence/CryptoAudit.kt
+++ b/workflow-persistence-jdbc/src/main/kotlin/com/example/workflow/persistence/CryptoAudit.kt
@@ -1,0 +1,12 @@
+package com.example.workflow.persistence
+
+data class HashChainEntry(
+    val sequence: Long,
+    val hash: ByteArray,
+    val previousHash: ByteArray?,
+    val algorithm: String = "SHA-256"
+)
+
+interface HashChainValidator {
+    fun validate(entries: List<HashChainEntry>): Boolean
+}

--- a/workflow-persistence-jdbc/src/main/kotlin/com/example/workflow/persistence/Outbox.kt
+++ b/workflow-persistence-jdbc/src/main/kotlin/com/example/workflow/persistence/Outbox.kt
@@ -1,0 +1,42 @@
+package com.example.workflow.persistence
+
+import java.time.Instant
+import java.util.UUID
+
+interface OutboxDispatcher {
+    suspend fun publishBatch(max: Int): Int
+}
+
+data class OutboxRecord(
+    val id: UUID,
+    val channel: String,
+    val key: String,
+    val headers: Map<String, String> = emptyMap(),
+    val payloadJson: String,
+    val createdAt: Instant,
+    val publishedAt: Instant? = null,
+    val attempts: Int = 0,
+    val lastError: String? = null
+)
+
+interface Archiver {
+    suspend fun archive(before: Instant): Int
+}
+
+interface Replayer {
+    suspend fun replay(range: SequenceRange): ReplayReport
+}
+
+data class SequenceRange(val fromInclusive: Long, val toInclusive: Long)
+
+data class ReplayReport(val replayed: Long, val failed: Long)
+
+interface SchemaRegistry {
+    fun current(type: String): Int
+    fun get(type: String, version: Int): String
+}
+
+interface EventUpcaster {
+    fun canUpcast(type: String, from: Int): Boolean
+    fun upcast(json: String, from: Int, to: Int): String
+}

--- a/workflow-persistence-jdbc/src/main/resources/db/migration/V1__v21_schema.sql
+++ b/workflow-persistence-jdbc/src/main/resources/db/migration/V1__v21_schema.sql
@@ -1,0 +1,48 @@
+CREATE TABLE IF NOT EXISTS outbox(
+  id UUID PRIMARY KEY,
+  channel TEXT NOT NULL,
+  msg_key TEXT NOT NULL,
+  headers JSONB NOT NULL DEFAULT '{}',
+  payload_json JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  published_at TIMESTAMPTZ NULL,
+  attempts INT NOT NULL DEFAULT 0,
+  last_error TEXT NULL,
+  tenant_id TEXT NOT NULL DEFAULT 'public'
+);
+CREATE INDEX IF NOT EXISTS outbox_published_idx ON outbox (published_at) WHERE published_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS archive_manifest(
+  id BIGSERIAL PRIMARY KEY,
+  range_from BIGINT NOT NULL,
+  range_to BIGINT NOT NULL,
+  location TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS schema_versions(
+  type TEXT,
+  version INT,
+  schema_json JSONB,
+  PRIMARY KEY(type, version)
+);
+
+ALTER TABLE IF EXISTS event_journal
+  ADD COLUMN IF NOT EXISTS prev_hash BYTEA,
+  ADD COLUMN IF NOT EXISTS hash BYTEA,
+  ADD COLUMN IF NOT EXISTS hash_algo TEXT DEFAULT 'SHA-256',
+  ADD COLUMN IF NOT EXISTS tenant_id TEXT NOT NULL DEFAULT 'public';
+
+ALTER TABLE IF EXISTS snapshots
+  ADD COLUMN IF NOT EXISTS tenant_id TEXT NOT NULL DEFAULT 'public';
+ALTER TABLE IF EXISTS timers
+  ADD COLUMN IF NOT EXISTS tenant_id TEXT NOT NULL DEFAULT 'public',
+  ADD COLUMN IF NOT EXISTS cron_expr TEXT NULL,
+  ADD COLUMN IF NOT EXISTS jitter_ms INT NULL,
+  ADD COLUMN IF NOT EXISTS tags TEXT[] DEFAULT '{}';
+ALTER TABLE IF EXISTS sagas
+  ADD COLUMN IF NOT EXISTS tenant_id TEXT NOT NULL DEFAULT 'public';
+ALTER TABLE IF EXISTS projection_offsets
+  ADD COLUMN IF NOT EXISTS tenant_id TEXT NOT NULL DEFAULT 'public';
+ALTER TABLE IF EXISTS child_workflows
+  ADD COLUMN IF NOT EXISTS tenant_id TEXT NOT NULL DEFAULT 'public';

--- a/workflow-persistence-jdbc/src/test/kotlin/com/example/workflow/persistence/OutboxTest.kt
+++ b/workflow-persistence-jdbc/src/test/kotlin/com/example/workflow/persistence/OutboxTest.kt
@@ -1,0 +1,22 @@
+package com.example.workflow.persistence
+
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OutboxTest {
+    @Test
+    fun `records default attempts`() {
+        val record = OutboxRecord(
+            id = UUID.randomUUID(),
+            channel = "order-events",
+            key = "order-1",
+            payloadJson = "{}",
+            createdAt = Instant.EPOCH
+        )
+
+        assertEquals(0, record.attempts)
+        assertEquals(null, record.publishedAt)
+    }
+}

--- a/workflow-projections/build.gradle.kts
+++ b/workflow-projections/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    `java-library`
+}
+
+apply(plugin = "org.jetbrains.kotlin.jvm")
+
+dependencies {
+    api(project(":workflow-core"))
+    api(kotlin("stdlib"))
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+    testImplementation(kotlin("test"))
+}
+
+java {
+    withSourcesJar()
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/workflow-projections/src/main/kotlin/com/example/workflow/projections/ProjectionInterfaces.kt
+++ b/workflow-projections/src/main/kotlin/com/example/workflow/projections/ProjectionInterfaces.kt
@@ -1,0 +1,34 @@
+package com.example.workflow.projections
+
+import com.example.workflow.core.StepEffect
+import kotlinx.coroutines.flow.Flow
+
+interface Projection {
+    val name: String
+    suspend fun start(from: Offset?)
+    suspend fun stop()
+}
+
+data class Offset(val journalSeq: Long)
+
+data class JournalEvent(
+    val type: String,
+    val workflowId: String,
+    val sequence: Long,
+    val payloadJson: String,
+    val tenantId: String
+)
+
+interface ProjectionHandler {
+    suspend fun on(event: JournalEvent, tx: ProjectionTx)
+}
+
+interface ProjectionTx {
+    suspend fun upsert(sql: String, params: List<Any?>)
+}
+
+interface ProjectionSupervisor {
+    val events: Flow<StepEffect<*, *, *>>
+    suspend fun ensureRunning(projection: Projection)
+    suspend fun shutdown(name: String)
+}

--- a/workflow-projections/src/test/kotlin/com/example/workflow/projections/ProjectionInterfacesTest.kt
+++ b/workflow-projections/src/test/kotlin/com/example/workflow/projections/ProjectionInterfacesTest.kt
@@ -1,0 +1,12 @@
+package com.example.workflow.projections
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ProjectionInterfacesTest {
+    @Test
+    fun `offset remembers sequence`() {
+        val offset = Offset(42)
+        assertEquals(42, offset.journalSeq)
+    }
+}

--- a/workflow-security/build.gradle.kts
+++ b/workflow-security/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    `java-library`
+}
+
+apply(plugin = "org.jetbrains.kotlin.jvm")
+
+dependencies {
+    api(project(":workflow-core"))
+    api(kotlin("stdlib"))
+    testImplementation(kotlin("test"))
+}
+
+java {
+    withSourcesJar()
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/workflow-security/src/main/kotlin/com/example/workflow/security/PolicyEngine.kt
+++ b/workflow-security/src/main/kotlin/com/example/workflow/security/PolicyEngine.kt
@@ -1,0 +1,34 @@
+package com.example.workflow.security
+
+data class Subject(val id: String, val roles: Set<String>)
+
+data class Action(val verb: String, val resourceType: String)
+
+data class Resource(val type: String, val id: String)
+
+enum class Decision { ALLOW, DENY, DEFER }
+
+fun interface PolicyEngine {
+    fun authorize(subject: Subject, action: Action, resource: Resource): Decision
+}
+
+data class AuditRecord(
+    val subject: Subject,
+    val action: Action,
+    val resource: Resource,
+    val decision: Decision,
+    val reason: String? = null
+)
+
+@Target(AnnotationTarget.PROPERTY)
+annotation class Sensitive(val field: String)
+
+fun interface Redactor {
+    fun redact(json: String): String
+}
+
+data class CryptoEnvelope(
+    val keyId: String,
+    val initializationVector: String,
+    val cipherText: String
+)

--- a/workflow-security/src/test/kotlin/com/example/workflow/security/PolicyEngineTest.kt
+++ b/workflow-security/src/test/kotlin/com/example/workflow/security/PolicyEngineTest.kt
@@ -1,0 +1,21 @@
+package com.example.workflow.security
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PolicyEngineTest {
+    @Test
+    fun `policy engine can be implemented with lambda`() {
+        val engine = PolicyEngine { subject, action, _ ->
+            if ("admin" in subject.roles && action.verb == "write") Decision.ALLOW else Decision.DENY
+        }
+
+        val decision = engine.authorize(
+            Subject("user-1", setOf("admin")),
+            Action("write", "workflow"),
+            Resource("workflow", "order-123")
+        )
+
+        assertEquals(Decision.ALLOW, decision)
+    }
+}

--- a/workflow-subflow/build.gradle.kts
+++ b/workflow-subflow/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    `java-library`
+}
+
+apply(plugin = "org.jetbrains.kotlin.jvm")
+
+dependencies {
+    api(project(":workflow-core"))
+    api(kotlin("stdlib"))
+    testImplementation(kotlin("test"))
+}
+
+java {
+    withSourcesJar()
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/workflow-subflow/src/main/kotlin/com/example/workflow/subflow/SubflowEffects.kt
+++ b/workflow-subflow/src/main/kotlin/com/example/workflow/subflow/SubflowEffects.kt
@@ -1,0 +1,35 @@
+package com.example.workflow.subflow
+
+import com.example.workflow.core.StepEffect
+
+data class ChildOptions(val awaitCompletion: Boolean = false, val correlationKey: String? = null)
+
+object SubflowEffects {
+    fun <S, E, R> startChild(
+        childType: String,
+        childId: String,
+        initialCommandJson: String,
+        options: ChildOptions = ChildOptions()
+    ): StepEffect<S, E, R> = StepEffect(
+        name = "start-child",
+        attributes = buildMap {
+            put("childType", childType)
+            put("childId", childId)
+            put("initialCommandJson", initialCommandJson)
+            put("awaitCompletion", options.awaitCompletion)
+            options.correlationKey?.let { put("correlationKey", it) }
+        }
+    )
+}
+
+data class ChildWorkflowStatus(
+    val parentType: String,
+    val parentId: String,
+    val childType: String,
+    val childId: String,
+    val status: Status,
+    val resultJson: String?,
+    val createdAtEpochMilli: Long
+) {
+    enum class Status { STARTED, COMPLETED, FAILED, CANCELLED }
+}

--- a/workflow-subflow/src/test/kotlin/com/example/workflow/subflow/SubflowEffectsTest.kt
+++ b/workflow-subflow/src/test/kotlin/com/example/workflow/subflow/SubflowEffectsTest.kt
@@ -1,0 +1,20 @@
+package com.example.workflow.subflow
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SubflowEffectsTest {
+    @Test
+    fun `start child encodes options`() {
+        val effect = SubflowEffects.startChild<Unit, Unit, Unit>(
+            childType = "Invoice",
+            childId = "123",
+            initialCommandJson = "{\"cmd\":\"start\"}",
+            options = ChildOptions(awaitCompletion = true, correlationKey = "order-1")
+        )
+
+        assertEquals("start-child", effect.name)
+        assertEquals(true, effect.attributes["awaitCompletion"])
+        assertEquals("order-1", effect.attributes["correlationKey"])
+    }
+}

--- a/workflow-timers/src/main/kotlin/com/example/workflow/timers/TimerEffects.kt
+++ b/workflow-timers/src/main/kotlin/com/example/workflow/timers/TimerEffects.kt
@@ -1,0 +1,32 @@
+package com.example.workflow.timers
+
+import com.example.workflow.core.StepEffect
+import kotlin.time.Duration
+
+object TimerEffects {
+    fun <S, E, R> scheduleCron(
+        key: String,
+        cron: String,
+        jitter: Duration? = null,
+        tags: Set<String> = emptySet()
+    ): StepEffect<S, E, R> = StepEffect(
+        name = "schedule-cron",
+        attributes = buildMap {
+            put("key", key)
+            put("cron", cron)
+            jitter?.let { put("jitterMillis", it.inWholeMilliseconds) }
+            if (tags.isNotEmpty()) put("tags", tags.toList())
+        }
+    )
+
+    fun <S, E, R> massReschedule(selector: TimerSelector, shift: Duration): StepEffect<S, E, R> = StepEffect(
+        name = "mass-reschedule",
+        attributes = buildMap {
+            selector.prefix?.let { put("prefix", it) }
+            if (selector.tags.isNotEmpty()) put("tags", selector.tags.toList())
+            put("shiftMillis", shift.inWholeMilliseconds)
+        }
+    )
+}
+
+data class TimerSelector(val prefix: String? = null, val tags: Set<String> = emptySet())

--- a/workflow-timers/src/test/kotlin/com/example/workflow/timers/TimerEffectsTest.kt
+++ b/workflow-timers/src/test/kotlin/com/example/workflow/timers/TimerEffectsTest.kt
@@ -1,0 +1,24 @@
+package com.example.workflow.timers
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.minutes
+
+class TimerEffectsTest {
+    @Test
+    fun `schedule cron carries attributes`() {
+        val effect = TimerEffects.scheduleCron<Unit, Unit, Unit>("billing", "*/5 * * * *", jitter = 1.minutes, tags = setOf("invoice"))
+        assertEquals("schedule-cron", effect.name)
+        assertEquals("billing", effect.attributes["key"])
+        assertEquals(listOf("invoice"), effect.attributes["tags"])
+    }
+
+    @Test
+    fun `mass reschedule encodes selector`() {
+        val selector = TimerSelector(prefix = "order", tags = setOf("sla"))
+        val effect = TimerEffects.massReschedule<Unit, Unit, Unit>(selector, 5.minutes)
+        assertEquals("mass-reschedule", effect.name)
+        assertEquals("order", effect.attributes["prefix"])
+        assertEquals(5.minutes.inWholeMilliseconds, effect.attributes["shiftMillis"])
+    }
+}


### PR DESCRIPTION
## Summary
- add v2.1 workflow core primitives for guard handling, command envelopes, and shared step effects
- create new feature modules (projections, human-in-the-loop, subflows, timers, security, admin, devtools) with stub APIs and sample tests
- extend persistence module with outbox/upcaster contracts, crypto audit structures, and flyway schema updates for multi-tenancy and timers

## Testing
- `./gradlew test --console=plain` *(fails: 403 Forbidden downloading kotlin-gradle-plugin due to restricted Maven access)*

------
https://chatgpt.com/codex/tasks/task_e_68e2f4dc13f883249a6de80bdc65fec6