### PR TITLE
Implement effect sequencing and guard DSL

### DIFF
--- a/platform-core/src/main/kotlin/com/example/platform/core/Effect.kt
+++ b/platform-core/src/main/kotlin/com/example/platform/core/Effect.kt
@@ -1,10 +1,22 @@
 package com.example.platform.core
 
 /**
- * Represents the outcome of handling a workflow command.
+ * Represents the frozen execution plan produced by a workflow command handler.
+ *
+ * An [Effect] records the full sequence of work that the runtime must execute in
+ * the following strict order:
+ *
+ * 1. Persist all [Result.events] to durable storage.
+ * 2. Apply each event to the current state via [Workflow.applyEvent] in order.
+ * 3. Apply the optional [Result.transition] to produce the final state.
+ * 4. Execute all queued side-effects with the latest state.
+ * 5. Produce the optional reply by invoking [Result.reply] with the final state.
  */
 public sealed class Effect<S, E, R> {
-    /** Terminal effect produced after composing events, transitions, side-effects and reply. */
+    /**
+     * Terminal effect produced after composing events, an optional transition,
+     * side-effects and an optional reply function.
+     */
     public data class Result<S, E, R>(
         val events: List<E>,
         val transition: Transition<S>?,
@@ -14,26 +26,72 @@ public sealed class Effect<S, E, R> {
 }
 
 /**
- * Builder for composing workflow side-effects before producing a terminal [Effect].
+ * Mutable-style builder used by workflow handlers to compose an [Effect].
+ *
+ * Implementations accumulate emitted events, a single state [Transition],
+ * zero or more side-effects and finally a terminal reply decision. Once a
+ * terminal method is invoked the builder yields an immutable [Effect.Result].
  */
-public class StepEffect<S, E, R> internal constructor(
-    internal val events: List<E>,
-    internal val transition: Transition<S>?,
-    internal val sideEffects: List<suspend (S) -> Unit>
-) {
-    /** Adds a suspending side-effect to execute after the state is finalized. */
-    public fun thenRun(action: suspend (S) -> Unit): StepEffect<S, E, R> =
-        StepEffect(events, transition, sideEffects + action)
+public interface StepEffect<S, E, R> {
+    /**
+     * Queues a suspending side-effect that will run after the state is finalized.
+     */
+    public fun thenRun(action: suspend (S) -> Unit): StepEffect<S, E, R>
 
-    /** Queues a state transition to run after events have been applied. */
-    public fun thenTransition(transform: (S) -> S): StepEffect<S, E, R> =
-        StepEffect(events, Transition(transform), sideEffects)
+    /**
+     * Schedules the single transition to run after events have been applied.
+     *
+     * @throws IllegalStateException if a transition was already provided.
+     */
+    public fun thenTransition(transform: (S) -> S): StepEffect<S, E, R>
 
-    /** Finishes the effect replying with a value derived from the latest state. */
-    public fun thenReply(responder: (S) -> R): Effect<S, E, R> =
-        Effect.Result(events, transition, sideEffects, responder)
+    /**
+     * Finishes the effect replying with a value derived from the latest state.
+     */
+    public fun thenReply(responder: (S) -> R): Effect<S, E, R>
 
-    /** Finishes the effect without replying. */
-    public fun thenNoReply(): Effect<S, E, R> =
-        Effect.Result(events, transition, sideEffects, null)
+    /**
+     * Finishes the effect without providing a reply.
+     */
+    public fun thenNoReply(): Effect<S, E, R>
+}
+
+internal class NormalStepEffectImpl<S, E, R> (
+    private val events: List<E>,
+    private val transition: Transition<S>?,
+    private val sideEffects: List<suspend (S) -> Unit>
+) : StepEffect<S, E, R> {
+    override fun thenRun(action: suspend (S) -> Unit): StepEffect<S, E, R> =
+        NormalStepEffectImpl(events, transition, sideEffects + action)
+
+    override fun thenTransition(transform: (S) -> S): StepEffect<S, E, R> {
+        if (transition != null) {
+            throw IllegalStateException("Transition already set")
+        }
+        return NormalStepEffectImpl(events, Transition(transform), sideEffects)
+    }
+
+    override fun thenReply(responder: (S) -> R): Effect<S, E, R> =
+        freeze(responder)
+
+    override fun thenNoReply(): Effect<S, E, R> =
+        freeze(null)
+
+    private fun freeze(reply: ((S) -> R)?): Effect<S, E, R> =
+        Effect.Result(events, transition, sideEffects, reply)
+}
+
+internal class RejectedStepEffectImpl<S, E, R>(
+    private val rejectionReply: (S) -> R
+) : StepEffect<S, E, R> {
+    private val frozen: Effect<S, E, R> =
+        Effect.Result(emptyList(), null, emptyList(), rejectionReply)
+
+    override fun thenRun(action: suspend (S) -> Unit): StepEffect<S, E, R> = this
+
+    override fun thenTransition(transform: (S) -> S): StepEffect<S, E, R> = this
+
+    override fun thenReply(responder: (S) -> R): Effect<S, E, R> = frozen
+
+    override fun thenNoReply(): Effect<S, E, R> = frozen
 }

--- a/platform-core/src/main/kotlin/com/example/platform/core/Effects.kt
+++ b/platform-core/src/main/kotlin/com/example/platform/core/Effects.kt
@@ -6,9 +6,9 @@ package com.example.platform.core
 public object Effects {
     /** Returns an effect that performs no persistence by default. */
     public fun <S, E, R> none(): StepEffect<S, E, R> =
-        StepEffect(emptyList(), null, emptyList())
+        NormalStepEffectImpl(emptyList(), null, emptyList())
 
     /** Persists the supplied events before any additional steps. */
     public fun <S, E, R> persist(vararg events: E): StepEffect<S, E, R> =
-        StepEffect(events.toList(), null, emptyList())
+        NormalStepEffectImpl(events.toList(), null, emptyList())
 }

--- a/platform-core/src/main/kotlin/com/example/platform/core/WorkflowContext.kt
+++ b/platform-core/src/main/kotlin/com/example/platform/core/WorkflowContext.kt
@@ -1,5 +1,7 @@
 package com.example.platform.core
 
+import com.example.platform.core.guard.GuardCheck
+import com.example.platform.core.guard.GuardCheckImpl
 import java.time.Instant
 
 /**
@@ -14,4 +16,15 @@ public interface WorkflowContext<S, C, E, R> {
 
     /** Returns the current instant. */
     public fun now(): Instant
+
+    /**
+     * Evaluates the [predicate] named [name] and returns a guard builder that
+     * can short-circuit workflow execution when the predicate fails.
+     */
+    public fun guard(
+        name: String,
+        state: S,
+        command: C,
+        predicate: (S, C) -> Boolean
+    ): GuardCheck<S, C, E, R> = GuardCheckImpl(name, state, command, predicate)
 }

--- a/platform-core/src/main/kotlin/com/example/platform/core/guard/Guard.kt
+++ b/platform-core/src/main/kotlin/com/example/platform/core/guard/Guard.kt
@@ -1,0 +1,55 @@
+package com.example.platform.core.guard
+
+import com.example.platform.core.RejectedStepEffectImpl
+import com.example.platform.core.StepEffect
+
+/**
+ * Builder returned from [com.example.platform.core.WorkflowContext.guard] that
+ * allows expressing guard failure handling strategies.
+ */
+public interface GuardCheck<S, C, E, R> {
+    /**
+     * Configures the guard to short-circuit with a rejection reply when the
+     * predicate fails.
+     */
+    public fun orReject(buildReply: (S) -> R): GuardGate<S, E, R>
+
+    /**
+     * Throws an [IllegalStateException] with the provided [message] when the
+     * predicate fails. When the predicate passes this method returns normally.
+     */
+    public fun orThrow(message: String = "Guard violated")
+}
+
+/**
+ * Represents the continuation of a guard configuration. Calling [then] either
+ * executes the provided [block] (when the guard passed) or returns a
+ * short-circuit [StepEffect] that reports the configured rejection.
+ */
+public fun interface GuardGate<S, E, R> {
+    public fun then(block: () -> StepEffect<S, E, R>): StepEffect<S, E, R>
+}
+
+internal class GuardCheckImpl<S, C, E, R>(
+    private val name: String,
+    private val state: S,
+    private val command: C,
+    private val predicate: (S, C) -> Boolean
+) : GuardCheck<S, C, E, R> {
+    private val passed: Boolean = predicate(state, command)
+
+    override fun orReject(buildReply: (S) -> R): GuardGate<S, E, R> {
+        return if (passed) {
+            GuardGate { builder -> builder() }
+        } else {
+            val rejection = RejectedStepEffectImpl<S, E, R>(buildReply)
+            GuardGate { rejection }
+        }
+    }
+
+    override fun orThrow(message: String) {
+        if (!passed) {
+            throw IllegalStateException("$message (guard=$name)")
+        }
+    }
+}

--- a/platform-runtime-local/src/main/kotlin/com/example/platform/runtime/local/WorkflowEngine.kt
+++ b/platform-runtime-local/src/main/kotlin/com/example/platform/runtime/local/WorkflowEngine.kt
@@ -13,12 +13,16 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 
-internal data class CommandEnvelope<C, R>(val command: C, val reply: CompletableDeferred<R?>)
+internal data class CommandEnvelope<C, R>(
+    val command: C,
+    val reply: CompletableDeferred<R?>,
+    val expectsReply: Boolean
+)
 
 /**
  * Executes workflow commands using an in-memory, single-threaded per-instance runtime.
  */
-public class WorkflowEngine<S, C, E, R>(
+public class WorkflowEngine<S, C, E, R> (
     private val workflow: Workflow<S, C, E, R>,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 ) {
@@ -86,11 +90,20 @@ public class WorkflowEngine<S, C, E, R>(
                 envelope.reply.completeExceptionally(t)
                 continue
             }
-            try {
-                val replyValue = result.reply?.invoke(currentState)
-                envelope.reply.complete(replyValue)
-            } catch (t: Throwable) {
-                envelope.reply.completeExceptionally(t)
+            val replyFn = result.reply
+            if (replyFn != null) {
+                try {
+                    val replyValue = replyFn(currentState)
+                    envelope.reply.complete(replyValue)
+                } catch (t: Throwable) {
+                    envelope.reply.completeExceptionally(t)
+                }
+            } else {
+                if (envelope.expectsReply) {
+                    envelope.reply.completeExceptionally(IllegalStateException("No reply for ask"))
+                } else {
+                    envelope.reply.complete(null)
+                }
             }
         }
     }

--- a/platform-runtime-local/src/main/kotlin/com/example/platform/runtime/local/WorkflowProxy.kt
+++ b/platform-runtime-local/src/main/kotlin/com/example/platform/runtime/local/WorkflowProxy.kt
@@ -14,7 +14,7 @@ public class WorkflowProxy<S, C, E, R> internal constructor(
     /** Sends the command expecting a reply. */
     public suspend fun ask(command: C): R {
         val deferred = CompletableDeferred<R?>()
-        mailbox.send(CommandEnvelope(command, deferred))
+        mailbox.send(CommandEnvelope(command, deferred, expectsReply = true))
         val result = deferred.await()
         return result ?: error("Workflow $id returned no reply for command $command")
     }
@@ -22,7 +22,7 @@ public class WorkflowProxy<S, C, E, R> internal constructor(
     /** Sends the command without awaiting a reply value. */
     public suspend fun tell(command: C) {
         val deferred = CompletableDeferred<R?>()
-        mailbox.send(CommandEnvelope(command, deferred))
+        mailbox.send(CommandEnvelope(command, deferred, expectsReply = false))
         deferred.await()
     }
 

--- a/sample-order/src/main/kotlin/com/example/sample/order/OrderWorkflow.kt
+++ b/sample-order/src/main/kotlin/com/example/sample/order/OrderWorkflow.kt
@@ -21,6 +21,11 @@ public data class OrderState(
     val status: OrderStatus
 )
 
+/** Side-effect hooks used by tests to observe workflow behaviour. */
+public object OrderWorkflowHooks {
+    public var onStateCommitted: ((OrderState) -> Unit)? = null
+}
+
 /** Supported commands for the order workflow. */
 @Command
 @Serializable
@@ -131,16 +136,17 @@ public class OrderWorkflow : Workflow<OrderState, OrderCommand, OrderEvent, Orde
             }
         }
         Ship -> {
-            if (state.status != OrderStatus.Approved) {
-                ctx.effects.none<OrderState, OrderEvent, OrderReply>().thenReply {
-                    OrderReply.Error("Only approved orders can be shipped", it)
+            ctx.guard("ship-requires-approved", state, command) { s, _ -> s.status == OrderStatus.Approved }
+                .orReject { OrderReply.Error("Only approved orders can be shipped", it) }
+                .then {
+                    ctx.effects
+                        .persist<OrderState, OrderEvent, OrderReply>(OrderShipped)
+                        .thenTransition { it.copy(status = OrderStatus.Shipped) }
+                        .thenRun { newState ->
+                            OrderWorkflowHooks.onStateCommitted?.invoke(newState)
+                        }
                 }
-            } else {
-                ctx.effects
-                    .persist<OrderState, OrderEvent, OrderReply>(OrderShipped)
-                    .thenTransition { it.copy(status = OrderStatus.Shipped) }
-                    .thenReply { OrderReply.Ok(it) }
-            }
+                .thenReply { OrderReply.Ok(it) }
         }
         Cancel -> {
             if (state.status !in setOf(OrderStatus.Created, OrderStatus.Approved)) {

--- a/sample-order/src/test/kotlin/com/example/sample/order/EffectDslTest.kt
+++ b/sample-order/src/test/kotlin/com/example/sample/order/EffectDslTest.kt
@@ -2,10 +2,15 @@ package com.example.sample.order
 
 import com.example.platform.core.Effect
 import com.example.platform.core.Effects
+import com.example.platform.core.StepEffect
+import com.example.platform.core.Workflow
+import com.example.platform.core.WorkflowContext
+import com.example.platform.runtime.local.WorkflowEngine
 import com.example.testing.Test
 import com.example.testing.assertEquals
 import com.example.testing.assertNotNull
 import com.example.testing.assertNull
+import kotlinx.coroutines.runBlocking
 
 class EffectDslTest {
     @Test
@@ -49,5 +54,112 @@ class EffectDslTest {
         val transitioned = result.transition?.toState?.invoke(state) ?: state
         assertEquals(16, transitioned)
         assertNull(result.reply)
+    }
+
+    @Test
+    fun eventsAreAppliedInOrderBeforeTransition() = runBlocking {
+        val applied = mutableListOf<Int>()
+        val workflow = RecordingWorkflow(applied, sideEffects = mutableListOf())
+        val engine = WorkflowEngine(workflow)
+        val proxy = engine.proxyFor("dsl-order-1")
+
+        val reply = proxy.ask(TestCommand.Execute)
+        assertEquals(16, reply)
+        assertEquals(listOf(1, 2, 3), applied)
+        assertEquals(16, proxy.state())
+        assertEquals(listOf(1, 2, 3), proxy.events())
+    }
+
+    @Test
+    fun transitionRunsAfterEvents() = runBlocking {
+        val workflow = RecordingWorkflow(mutableListOf(), sideEffects = mutableListOf())
+        val engine = WorkflowEngine(workflow)
+        val proxy = engine.proxyFor("dsl-order-2")
+
+        proxy.ask(TestCommand.Execute)
+        assertEquals(16, proxy.state())
+    }
+
+    @Test
+    fun sideEffectsSeeFinalState() = runBlocking {
+        val seen = mutableListOf<String>()
+        val workflow = RecordingWorkflow(mutableListOf(), sideEffects = seen)
+        val engine = WorkflowEngine(workflow)
+        val proxy = engine.proxyFor("dsl-order-3")
+
+        proxy.ask(TestCommand.Execute)
+        assertEquals(listOf("16"), seen)
+    }
+
+    @Test
+    fun sideEffectFailureDoesNotRollback() = runBlocking {
+        val workflow = object : Workflow<Int, TestCommand, Int, Int> {
+            override val name: String = "FailingSideEffect"
+            override fun initialState(id: String): Int = 0
+            override fun applyEvent(state: Int, event: Int): Int = state + event
+            override fun onCommand(
+                state: Int,
+                command: TestCommand,
+                ctx: WorkflowContext<Int, TestCommand, Int, Int>
+            ): Effect<Int, Int, Int> {
+                return Effects
+                    .persist<Int, Int, Int>(1, 2, 3)
+                    .thenTransition { it + 10 }
+                    .thenRun { throw IllegalStateException("boom") }
+                    .thenReply { it }
+            }
+        }
+        val engine = WorkflowEngine(workflow)
+        val proxy = engine.proxyFor("dsl-order-4")
+
+        try {
+            proxy.ask(TestCommand.Execute)
+            error("Expected exception")
+        } catch (t: IllegalStateException) {
+            assertEquals("boom", t.message)
+        }
+        assertEquals(16, proxy.state())
+        assertEquals(listOf(1, 2, 3), proxy.events())
+    }
+
+    @Test
+    fun onlySingleTransitionAllowed() {
+        val step: StepEffect<Int, Int, Int> = Effects.persist(1)
+        try {
+            step
+                .thenTransition { it + 1 }
+                .thenTransition { it + 2 }
+            error("Expected IllegalStateException")
+        } catch (t: IllegalStateException) {
+            assertEquals("Transition already set", t.message)
+        }
+    }
+}
+
+private enum class TestCommand { Execute }
+
+private class RecordingWorkflow(
+    private val applied: MutableList<Int>,
+    private val sideEffects: MutableList<String>
+) : Workflow<Int, TestCommand, Int, Int> {
+    override val name: String = "RecordingWorkflow"
+
+    override fun initialState(id: String): Int = 0
+
+    override fun applyEvent(state: Int, event: Int): Int {
+        applied += event
+        return state + event
+    }
+
+    override fun onCommand(
+        state: Int,
+        command: TestCommand,
+        ctx: WorkflowContext<Int, TestCommand, Int, Int>
+    ): Effect<Int, Int, Int> {
+        return Effects
+            .persist<Int, Int, Int>(1, 2, 3)
+            .thenTransition { it + 10 }
+            .thenRun { sideEffects += it.toString() }
+            .thenReply { it }
     }
 }

--- a/sample-order/src/test/kotlin/com/example/sample/order/GuardDslTest.kt
+++ b/sample-order/src/test/kotlin/com/example/sample/order/GuardDslTest.kt
@@ -1,0 +1,131 @@
+package com.example.sample.order
+
+import com.example.platform.core.Effect
+import com.example.platform.core.Effects
+import com.example.platform.core.Workflow
+import com.example.platform.core.WorkflowContext
+import com.example.platform.runtime.local.WorkflowEngine
+import com.example.testing.Test
+import com.example.testing.assertEquals
+import com.example.testing.assertIs
+import kotlinx.coroutines.runBlocking
+
+class GuardDslTest {
+    @Test
+    fun guardPassesAndExecutesPlan() = runBlocking {
+        val sideEffects = mutableListOf<String>()
+        val workflow = GuardWorkflow(initialReady = true, sideEffects)
+        val engine = WorkflowEngine(workflow)
+        val proxy = engine.proxyFor("guard-1")
+
+        val reply = proxy.ask(GuardCommand.Perform)
+        assertIs<GuardReply.Ok>(reply)
+        assertEquals("done", reply.state.status)
+        assertEquals(
+            listOf(
+                GuardEvent.Recorded("first"),
+                GuardEvent.Recorded("second")
+            ),
+            proxy.events()
+        )
+        assertEquals("done", proxy.state().status)
+        assertEquals(listOf("done"), sideEffects)
+    }
+
+    @Test
+    fun guardRejectsWithoutSideEffects() = runBlocking {
+        val sideEffects = mutableListOf<String>()
+        val workflow = GuardWorkflow(initialReady = false, sideEffects)
+        val engine = WorkflowEngine(workflow)
+        val proxy = engine.proxyFor("guard-2")
+
+        val reply = proxy.ask(GuardCommand.Perform)
+        assertIs<GuardReply.Rejected>(reply)
+        val rejection = reply as GuardReply.Rejected
+        assertEquals("Not ready", rejection.message)
+        assertEquals(emptyList<GuardEvent>(), proxy.events())
+        assertEquals("initial", proxy.state().status)
+        assertEquals(emptyList<String>(), sideEffects)
+    }
+
+    @Test
+    fun guardThrowsWhenConfigured() = runBlocking {
+        val workflow = GuardWorkflow(initialReady = false, sideEffects = mutableListOf())
+        val engine = WorkflowEngine(workflow)
+        val proxy = engine.proxyFor("guard-3")
+
+        try {
+            proxy.ask(GuardCommand.Throw)
+            error("Expected failure")
+        } catch (t: IllegalStateException) {
+            assertEquals("Cannot execute (guard=must-be-ready)", t.message)
+        }
+        assertEquals(emptyList<GuardEvent>(), proxy.events())
+        assertEquals("initial", proxy.state().status)
+    }
+}
+
+private data class GuardState(
+    val ready: Boolean,
+    val status: String,
+    val history: List<String>
+)
+
+private sealed interface GuardCommand {
+    data object Perform : GuardCommand
+    data object Throw : GuardCommand
+}
+
+private sealed interface GuardEvent {
+    data class Recorded(val marker: String) : GuardEvent
+    data class ReadyChanged(val ready: Boolean) : GuardEvent
+}
+
+private sealed interface GuardReply {
+    val state: GuardState
+
+    data class Ok(override val state: GuardState) : GuardReply
+    data class Rejected(val message: String, override val state: GuardState) : GuardReply
+}
+
+private class GuardWorkflow(
+    private val initialReady: Boolean,
+    private val sideEffects: MutableList<String>
+) : Workflow<GuardState, GuardCommand, GuardEvent, GuardReply> {
+    override val name: String = "GuardWorkflow"
+
+    override fun initialState(id: String): GuardState =
+        GuardState(initialReady, status = "initial", history = emptyList())
+
+    override fun applyEvent(state: GuardState, event: GuardEvent): GuardState = when (event) {
+        is GuardEvent.Recorded -> state.copy(history = state.history + event.marker)
+        is GuardEvent.ReadyChanged -> state.copy(ready = event.ready)
+    }
+
+    override fun onCommand(
+        state: GuardState,
+        command: GuardCommand,
+        ctx: WorkflowContext<GuardState, GuardCommand, GuardEvent, GuardReply>
+    ): Effect<GuardState, GuardEvent, GuardReply> = when (command) {
+        GuardCommand.Perform -> ctx.guard("ready-check", state, command) { s, _ -> s.ready }
+            .orReject { GuardReply.Rejected("Not ready", it) }
+            .then {
+                Effects
+                    .persist<GuardState, GuardEvent, GuardReply>(
+                        GuardEvent.Recorded("first"),
+                        GuardEvent.Recorded("second")
+                    )
+                    .thenTransition { it.copy(status = "done") }
+                    .thenRun { sideEffects += it.status }
+            }
+            .thenReply { GuardReply.Ok(it) }
+
+        GuardCommand.Throw -> {
+            ctx.guard("must-be-ready", state, command) { s, _ -> s.ready }
+                .orThrow("Cannot execute")
+            Effects
+                .none<GuardState, GuardEvent, GuardReply>()
+                .thenReply { GuardReply.Ok(it) }
+        }
+    }
+}

--- a/sample-order/src/test/kotlin/com/example/sample/order/OrderWorkflowTest.kt
+++ b/sample-order/src/test/kotlin/com/example/sample/order/OrderWorkflowTest.kt
@@ -12,15 +12,21 @@ class OrderWorkflowTest {
         val workflow = OrderWorkflow()
         val engine = WorkflowEngine(workflow)
         val proxy = engine.proxyFor("order-test")
+        val observed = mutableListOf<OrderStatus>()
+        OrderWorkflowHooks.onStateCommitted = { observed += it.status }
 
-        val create = proxy.ask(CreateOrder("Bob"))
-        assertIs<OrderReply.Ok>(create)
-        val add1 = proxy.ask(AddItem("Item-1"))
-        assertIs<OrderReply.Ok>(add1)
-        val approve = proxy.ask(Approve)
-        assertIs<OrderReply.Ok>(approve)
-        val ship = proxy.ask(Ship)
-        assertIs<OrderReply.Ok>(ship)
+        try {
+            val create = proxy.ask(CreateOrder("Bob"))
+            assertIs<OrderReply.Ok>(create)
+            val add1 = proxy.ask(AddItem("Item-1"))
+            assertIs<OrderReply.Ok>(add1)
+            val approve = proxy.ask(Approve)
+            assertIs<OrderReply.Ok>(approve)
+            val ship = proxy.ask(Ship)
+            assertIs<OrderReply.Ok>(ship)
+        } finally {
+            OrderWorkflowHooks.onStateCommitted = null
+        }
 
         val finalState = proxy.state()
         assertEquals(OrderStatus.Shipped, finalState.status)
@@ -34,5 +40,6 @@ class OrderWorkflowTest {
             ),
             proxy.events()
         )
+        assertEquals(listOf(OrderStatus.Shipped), observed)
     }
 }


### PR DESCRIPTION
## Summary
- rework the effect builder to enforce ordered persistence, transition, side-effects, and reply along with single-transition enforcement
- add a guard DSL that short-circuits command handling with typed rejections or exceptions and update the runtime to honour the new semantics
- update the order workflow to use guards, expose a hook for state observation, and extend the test suite with new guard and effect behaviour checks

## Testing
- ./gradlew clean build
- ./gradlew test
- ./gradlew :sample-order:run

------
https://chatgpt.com/codex/tasks/task_e_68e3183d657c832498cfbcd5bed56595